### PR TITLE
disable reset link after password update

### DIFF
--- a/routes/users.js
+++ b/routes/users.js
@@ -1516,7 +1516,7 @@ router.get('/user/:id/passwordreset/:key', async function(req, res){
         }
 
         // disable previous link sent
-        var new_key = Math.random().toString(36).substring(7);
+        let new_key = Math.random().toString(36).substring(7);
         await utils.mongo_users().updateOne({uid: req.params.id},{'$set': {regkey: new_key}});
 
         // Now send email


### PR DESCRIPTION
because some "security" program like sbr firewall read all mail and try to go on each link it find ...
so it is to avoid multiple mail with different password on each reset 