### PR TITLE
Fix log order by updating date format

### DIFF
--- a/manager2/src/app/admin/logs/logs.component.ts
+++ b/manager2/src/app/admin/logs/logs.component.ts
@@ -25,6 +25,7 @@ export class LogsComponent implements OnInit {
 
     constructor(private http: HttpClient, private authService: AuthService) { }
 
+    // it look like this is useless, as in fact in compare string, not date ...
     private sortByDate(a, b) {
         if (a.date < b.date)
             return 1;
@@ -62,7 +63,7 @@ export class LogsComponent implements OnInit {
 
     date_convert = function timeConverter(tsp){
         var a = new Date(tsp);
-        return a.toLocaleDateString();
+        return a.toISOString();
     }
 
     getLogs(): Observable<any> {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/882203/70539182-9abcd400-1b63-11ea-9e0a-d3992953e73b.png)


I don't know if bug have been introduced here: https://github.com/genouest/genouestaccountmanager/pull/124/files

Or if it have been here for a long time ...