### PR TITLE
remove num forced uidnumber for ifb template

### DIFF
--- a/templates/ifb/user/add_user.sh
+++ b/templates/ifb/user/add_user.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-/usr/local/bin/num create-user --firstname="{{ user.firstname }}" --lastname="{{ user.lastname }}" --email="{{ user.email }}" --username="{{ user.uid }}" {% if user.uidnumber %}--uid_number="{{ user.uidnumber }}"{% endif %} {% if user.home %}--home_dir="{{ user.home }}"{% endif %} {% if user.password %}--password="{{ user.password }}"{% endif %}
+/usr/local/bin/num create-user --firstname="{{ user.firstname }}" --lastname="{{ user.lastname }}" --email="{{ user.email }}" --username="{{ user.uid }}" {% if user.home %}--home_dir="{{ user.home }}"{% endif %} {% if user.password %}--password="{{ user.password }}"{% endif %}
 
 # warning: disable ldap as it should have been done by num, but we don't know what is the dn created yet
 


### PR DESCRIPTION
as we don't need it at ifb, as we sync uidnumber and gidnumber via a cronned task between our ldap and my

please could you add a tag after merge
