### PR TITLE
start using run_plugin

### DIFF
--- a/core/user.service.js
+++ b/core/user.service.js
@@ -1,4 +1,3 @@
-const Promise = require('promise');
 const winston = require('winston');
 const logger = winston.loggers.get('gomngr');
 const crypto = require('crypto');
@@ -106,24 +105,13 @@ async function create_extra_user(user_name, group, internal_user){
         throw error;
     }
 
-    let plugin_call = function(plugin_info, userId, data, adminId){
-        // eslint-disable-next-line no-unused-vars
-        return new Promise(function (resolve, reject){
-            let plugins_modules = plgsrv.plugins_modules();
-            plugins_modules[plugin_info.name].activate(userId, data, adminId).then(function(){
-                resolve(true);
-            });
-        });
-    };
 
     try {
-        let plugins_info = plgsrv.plugins_info();
-        await Promise.all(plugins_info.map(function(plugin_info){
-            return plugin_call(plugin_info, user.uid, user, 'auto');
-        }));
+        await plgsrv.run_plugins('activate', user.uid, user, 'auto');
     } catch(err) {
-        logger.error('failed to create extra user', user, err);
+        logger.error('activation errors', user, err);
     }
+
     return user;
 }
 
@@ -435,23 +423,11 @@ async function delete_user(user, action_owner_id, message){
     }
 
     if(user_is_activ){
-        // Call remove method of plugins if defined
-        let plugin_call = function(plugin_info, userId, user, adminId){
-            // eslint-disable-next-line no-unused-vars
-            return new Promise(function (resolve, reject){
-                let plugins_modules = plgsrv.plugins_modules();
-                if(plugins_modules[plugin_info.name].remove === undefined) {
-                    resolve(true);
-                }
-                plugins_modules[plugin_info.name].remove(userId, user, adminId).then(function(){
-                    resolve(true);
-                });
-            });
-        };
-        let plugins_info = plgsrv.plugins_info();
-        await Promise.all(plugins_info.map(function(plugin_info){
-            return plugin_call(plugin_info, user.uid, user, action_owner_id);
-        }));
+        try {
+            await plgsrv.run_plugins('remove', user.uid, user, action_owner_id);
+        } catch(err) {
+            logger.error('remove errors', err);
+        }
     }
 
     await idsrv.freeUserId(user.uidnumber);

--- a/routes/tp.js
+++ b/routes/tp.js
@@ -311,20 +311,11 @@ var activate_tp_user = async function(user, adminId){
         logger.error('Add User Failed for: ' + user.uid, error);
     }
 
-
-    let plugin_call = function(plugin_info, userId, data, adminId){
-        // eslint-disable-next-line no-unused-vars
-        return new Promise(function (resolve, reject){
-            let plugins_modules = plgsrv.plugins_modules();
-            plugins_modules[plugin_info.name].activate(userId, data, adminId).then(function(){
-                resolve(true);
-            });
-        });
-    };
-    let plugins_info = plgsrv.plugins_info();
-    await Promise.all(plugins_info.map(function(plugin_info){
-        return plugin_call(plugin_info, user.uid, ldap_user, adminId);
-    }));
+    try {
+        await plgsrv.run_plugins('activate', user.uid, ldap_user, adminId);
+    } catch(err) {
+        logger.error('activation errors', err);
+    }
     return ldap_user;
 
 };

--- a/routes/users.js
+++ b/routes/users.js
@@ -6,7 +6,6 @@ const markdown = require('markdown').markdown;
 const htmlToText = require('html-to-text');
 const validator = require('email-validator');
 const crypto = require('crypto');
-const Promise = require('promise');
 const winston = require('winston');
 const logger = winston.loggers.get('gomngr');
 
@@ -689,48 +688,6 @@ router.get('/user/:id/activate', async function(req, res) {
         res.send({message: 'Activation in progress', fid: fid, error: []});
         res.end();
     }
-
-    /*
-    let plugin_call = function(plugin_info, userId, data, adminId){
-        // eslint-disable-next-line no-unused-vars
-        return new Promise(function (resolve, reject){
-            let plugins_modules = plgsrv.plugins_modules();
-            plugins_modules[plugin_info.name].activate(userId, data, adminId).then(function(){
-                resolve(true);
-            });
-        });
-    };
-    let plugins_info = plgsrv.plugins_info();
-    Promise.all(plugins_info.map(function(plugin_info){
-        return plugin_call(plugin_info, user.uid, user, session_user.uid);
-        // eslint-disable-next-line no-unused-vars
-    })).then(function(results){
-        if(user.is_fake) {
-            res.send({message: 'Activation in progress', fid: fid, error: []});
-            res.end();
-            return;      
-        } 
-        notif.add(user.email).then(() => {
-            res.send({message: 'Activation in progress', fid: fid, error: []});
-            res.end();
-        });
-        return;
-    }, function(err){
-        if(user.is_fake) {
-            res.send({message: 'Activation error', fid: fid, error: err});
-            res.end();
-            return;      
-        } 
-        notif.add(user.email).then(() => {
-            logger.error('[notif][error=add][mail=' + user.email + ']');
-            res.send({message: 'Activation error', fid: fid, error: err});
-            res.end();
-        });
-        return;
-    });
-    */
-
-
 });
 
 // Get user - for logged user or admin
@@ -1074,27 +1031,9 @@ router.get('/user/:id/expire', async function(req, res){
         try {
             // eslint-disable-next-line no-unused-vars
             await notif.remove(user.email);
-            let plugin_call = function(plugin_info, userId, user, adminId){
-                // eslint-disable-next-line no-unused-vars
-                return new Promise(function (resolve, reject){
-                    let plugins_modules = plgsrv.plugins_modules();
-                    plugins_modules[plugin_info.name].deactivate(userId, user, adminId).then(function(){
-                        resolve(true);
-                    });
-                });
-            };
-            let plugins_info = plgsrv.plugins_info();
-            Promise.all(plugins_info.map(function(plugin_info){
-                return plugin_call(plugin_info, user.uid, user, session_user.uid);
-                // eslint-disable-next-line no-unused-vars
-            })).then(function(data){
-                res.send({message: 'Operation in progress', fid: fid, error: []});
-                res.end();
-                return;
-            }, function(errs){
-                res.send({message: 'Operation in progress', fid: fid, error: errs});
-                res.end();
-            });
+            await plgsrv.run_plugins('deactivate', user.uid, user, session_user.uid);
+            res.send({message: 'Operation in progress', fid: fid, error: []});
+            res.end();     
         }
         catch(error) {
             res.send({message: 'Operation in progress, user not in mailing list', fid: fid, error: error});
@@ -1407,44 +1346,29 @@ router.get('/user/:id/renew', async function(req, res){
             logger.error(error);
         }
 
-        let plugin_call = function(plugin_info, userId, data, adminId){
-            // eslint-disable-next-line no-unused-vars
-            return new Promise(function (resolve, reject){
-                let plugins_modules = plgsrv.plugins_modules();
-                plugins_modules[plugin_info.name].activate(userId, data, adminId).then(function(){
-                    resolve(true);
-                });
-            });
-        };
-        let plugins_info = plgsrv.plugins_info();
-        Promise.all(plugins_info.map(function(plugin_info){
-            return plugin_call(plugin_info, user.uid, user, session_user.uid);
-            // eslint-disable-next-line no-unused-vars
-        })).then(function(results){
-            if(user.is_fake) {
-                res.send({message: 'Activation in progress', fid: fid, error: []});
-                res.end();
-                return;      
+        let error = false;
+        try {
+            error = await plgsrv.run_plugins('activate', user.uid, user, session_user.uid);
+        } catch(err) {
+            logger.error('activation errors', err);
+            error = true;
+        }
+    
+        if(!user.is_fake) {
+            try {
+                await notif.add(user.email);
+            } catch (err) {
+                logger.error('[notif][error=add][mail=' + user.email + ']');
             }
-            notif.add(user.email).then(() => {
-                res.send({message: 'Activation in progress', fid: fid, error: []});
-                res.end();
-                return;
-            });
-            return;
-        }, function(err){
-            if(user.is_fake) {
-                res.send({message: 'Activation Error', fid: fid, error: err});
-                res.end();
-                return;      
-            }
-            notif.add(user.email).then(() => {
-                res.send({message: 'Activation Error', fid: fid, error: err});
-                res.end();
-            });
-            return;
-        });
+        }
 
+        if(error) {
+            res.send({message: 'Activation Error', fid: fid, error: []});
+            res.end();
+        } else {
+            res.send({message: 'Activation in progress', fid: fid, error: []});
+            res.end();
+        }
         return;
     }
     else {
@@ -1689,30 +1613,11 @@ router.put('/user/:id', async function(req, res) {
 
     }
 
-
-    let plugin_call = function(plugin_info, userId, data, adminId){
-        // eslint-disable-next-line no-unused-vars
-        return new Promise(function (resolve, reject){
-            let plugins_modules = plgsrv.plugins_modules();
-            if (plugins_modules[plugin_info.name].update !== undefined) {
-                plugins_modules[plugin_info.name].update(userId, data, adminId).then(function(){
-                    resolve(true);
-                });
-            } else {
-                resolve(true);
-            }
-        });
-    };
-
     try {
-        let plugins_info = plgsrv.plugins_info();
-        await Promise.all(plugins_info.map(function(plugin_info){
-            return plugin_call(plugin_info, user.uid, user, session_user.uid);
-        }));
+        await plgsrv.run_plugins('update', user.uid, user, session_user.uid);
     } catch(err) {
-        logger.error('failed to update user', user, err);
+        logger.error('update errors', err);
     }
-
 
     if(user.status == STATUS_ACTIVE){
         await dbsrv.mongo_users().replaceOne({_id: user._id}, user);


### PR DESCRIPTION
Use new function *run_plugins* in plugin core service.

Instead of plugin_call and Promise.all multiple calls, just using something like:

    try {
        await plgsrv.run_plugins('activate', user.uid, user, 'auto');
    } catch(err) {
        logger.error('activation errors', user, err);
    }

run_plugins takes first argument as plugin function to call. If not present, will log and ignore the plugin for this call.

all plugins are executed sequentially with await, if one plugin fails, other plugins are executed anyway

it returns a boolean indicating if at least one error occured