### PR TITLE
Allow admin to create account

### DIFF
--- a/core/project.service.js
+++ b/core/project.service.js
@@ -83,6 +83,9 @@ async function create_project_request(asked_project, user) {
     });
 
     let msg_destinations =  [CONFIG.general.accounts, user.email];
+    if (user.email_does_not_exist) {
+        msg_destinations.push(CONFIG.general.support);
+    }
 
     try {
         await maisrv.send_notif_mail({

--- a/core/project.service.js
+++ b/core/project.service.js
@@ -83,7 +83,7 @@ async function create_project_request(asked_project, user) {
     });
 
     let msg_destinations =  [CONFIG.general.accounts, user.email];
-    if (user.email_does_not_exist) {
+    if (user.send_copy_to_support) {
         msg_destinations.push(CONFIG.general.support);
     }
 

--- a/core/user.service.js
+++ b/core/user.service.js
@@ -324,7 +324,7 @@ async function add_user_to_project(newproject, uid, action_owner) {
     if (owner) {
         msg_destinations.push(owner.email);
     }
-    if (user.email_does_not_exist) {
+    if (user.send_copy_to_support) {
         msg_destinations.push(CONFIG.general.support);
     }
 
@@ -410,7 +410,7 @@ async function delete_user(user, action_owner_id, message){
     if (message && message.length > 1) {
         mail_message = message;
         msg_destinations.push(user.email);
-        if (user.email_does_not_exist) {
+        if (user.send_copy_to_support) {
             msg_destinations.push(CONFIG.general.support);
         }
 

--- a/core/user.service.js
+++ b/core/user.service.js
@@ -324,6 +324,9 @@ async function add_user_to_project(newproject, uid, action_owner) {
     if (owner) {
         msg_destinations.push(owner.email);
     }
+    if (user.email_does_not_exist) {
+        msg_destinations.push(CONFIG.general.support);
+    }
 
     try {
         await maisrv.send_notif_mail({
@@ -407,6 +410,10 @@ async function delete_user(user, action_owner_id, message){
     if (message && message.length > 1) {
         mail_message = message;
         msg_destinations.push(user.email);
+        if (user.email_does_not_exist) {
+            msg_destinations.push(CONFIG.general.support);
+        }
+
     }
 
     try {

--- a/manager2/src/app/app.component.html
+++ b/manager2/src/app/app.component.html
@@ -39,7 +39,7 @@
           <li *ngIf="user && user.is_admin" class="nav-item dropdown">
             <a href="" id="dropdownMenu1" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i class="glyphicon glyphicon-cog"></i> Admin</a>
             <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
-                <li><a class="dropdown-item" routerLink="/register">Create User</a></li>
+                <li><a class="dropdown-item" routerLink="/register">New Account</a></li>
                 <li><a class="dropdown-item" routerLink="/admin/user">Users</a></li>
               <li><a class="dropdown-item" routerLink="/admin/group">Groups</a></li>
               <li><a class="dropdown-item" routerLink="/admin/project">Projects</a></li>

--- a/manager2/src/app/app.component.html
+++ b/manager2/src/app/app.component.html
@@ -39,7 +39,8 @@
           <li *ngIf="user && user.is_admin" class="nav-item dropdown">
             <a href="" id="dropdownMenu1" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i class="glyphicon glyphicon-cog"></i> Admin</a>
             <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
-              <li><a class="dropdown-item" routerLink="/admin/user">Users</a></li>
+                <li><a class="dropdown-item" routerLink="/register">Create User</a></li>
+                <li><a class="dropdown-item" routerLink="/admin/user">Users</a></li>
               <li><a class="dropdown-item" routerLink="/admin/group">Groups</a></li>
               <li><a class="dropdown-item" routerLink="/admin/project">Projects</a></li>
               <li *ngIf="config.enable_ui && config.enable_ui.messages"><a class="dropdown-item" routerLink="/admin/message">Send message</a></li>

--- a/manager2/src/app/auth/register/register.component.html
+++ b/manager2/src/app/auth/register/register.component.html
@@ -33,7 +33,7 @@
                     <label><input type="checkbox" [ngModelOptions]="{standalone: true}" [(ngModel)]="send_copy_to_support"> Send a Copy of all mail to Support Team (include mail with password)</label>
                 </div>
                 <div class="checkbox">
-                    <label><input type="checkbox" [ngModelOptions]="{standalone: true}" [(ngModel)]="create_imap_mailbox"> Create Imap Mailbox</label>
+                    <label><input type="checkbox" [ngModelOptions]="{standalone: true}" [(ngModel)]="create_imap_mailbox"> Create Imap Mailbox (if enable in cluster template)</label>
                 </div>
                 <div class="checkbox">
                     <label><input type="checkbox" [ngModelOptions]="{standalone: true}" [(ngModel)]="is_fake"> Flag as Fake Account (Applicative account)</label>

--- a/manager2/src/app/auth/register/register.component.html
+++ b/manager2/src/app/auth/register/register.component.html
@@ -28,6 +28,9 @@
                 <input autocomplete="email" [ngModelOptions]="{standalone: true}" [(ngModel)]="email" type="email" id="email" class="form-control" required autofocus>
                 <small id="emailHelp" class="form-text text-muted">Please provide a professional email address (please avoid gmail, yahoo, etc.).</small>
             </div>
+            <div *ngIf="session_user && session_user.is_admin" class="checkbox">
+                <label><input type="checkbox" [ngModelOptions]="{standalone: true}" [(ngModel)]="copy_to_admin" checked>Send a Copy of all mail to admin (include mail with password)</label>
+            </div>
             <br>
             <span class="glyphicon glyphicon-home" aria-hidden="true"></span>
             <i>Laboratory information</i>
@@ -77,16 +80,15 @@
             <input *ngIf="config.enable_ui && config.enable_ui.ip" type="hidden" [ngModelOptions]="{standalone: true}" [(ngModel)]="ip" type="text" id="ip" class="form-control" placeholder="IP Address" required>
             <br>
             <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-            <div *ngIf="! session_user">
             <i>Terms of use</i>
             <hr>
             <div class="checkbox">
                 <label><input type="checkbox" [ngModelOptions]="{standalone: true}" [(ngModel)]="agree" required>I agree with the <a target="_blank" aria-label="terms of user" href="{{config.terms_of_use}}">terms of use</a> of the {{config.name}} platform</label>
             </div>
-            <button type="button" class="btn btn-lg btn-primary btn-block" (click)="register();">Register</button>
+            <div *ngIf="! session_user">
+                <button type="button" class="btn btn-lg btn-primary btn-block" (click)="register();">Register</button>
             </div>
             <div *ngIf="session_user && session_user.is_admin">
-                <input type="hidden" [ngModelOptions]="{standalone: true}" [(ngModel)]="agree" value="true" />
                 <button type="button" class="btn btn-lg btn-primary btn-block" (click)="register();">Create New User</button>
             </div>
             <div *ngIf="msg">

--- a/manager2/src/app/auth/register/register.component.html
+++ b/manager2/src/app/auth/register/register.component.html
@@ -89,7 +89,7 @@
                 <button type="button" class="btn btn-lg btn-primary btn-block" (click)="register();">Register</button>
             </div>
             <div *ngIf="session_user && session_user.is_admin">
-                <button type="button" class="btn btn-lg btn-primary btn-block" (click)="register();">Create New User</button>
+                <button type="button" class="btn btn-lg btn-primary btn-block" (click)="register();">Create New Account</button>
             </div>
             <div *ngIf="msg">
                 <div class="alert alert-warning">{{msg}}</div>

--- a/manager2/src/app/auth/register/register.component.html
+++ b/manager2/src/app/auth/register/register.component.html
@@ -37,7 +37,7 @@
                 </div>
                 <div class="checkbox">
                     <label><input type="checkbox" [ngModelOptions]="{standalone: true}" [(ngModel)]="is_fake"> Flag as Fake Account (Applicative account)</label>
-                </div
+                </div>
             </div>
             <br>
             <span class="glyphicon glyphicon-home" aria-hidden="true"></span>

--- a/manager2/src/app/auth/register/register.component.html
+++ b/manager2/src/app/auth/register/register.component.html
@@ -77,12 +77,18 @@
             <input *ngIf="config.enable_ui && config.enable_ui.ip" type="hidden" [ngModelOptions]="{standalone: true}" [(ngModel)]="ip" type="text" id="ip" class="form-control" placeholder="IP Address" required>
             <br>
             <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
+            <div *ngIf="session_user">
             <i>Terms of use</i>
             <hr>
             <div class="checkbox">
                 <label><input type="checkbox" [ngModelOptions]="{standalone: true}" [(ngModel)]="agree" required>I agree with the <a target="_blank" aria-label="terms of user" href="{{config.terms_of_use}}">terms of use</a> of the {{config.name}} platform</label>
             </div>
             <button type="button" class="btn btn-lg btn-primary btn-block" (click)="register();">Register</button>
+            </div>
+            <div *ngIf="session_user">
+                <input type="hidden" [ngModelOptions]="{standalone: true}" [(ngModel)]="agree" value="true" />
+                <button type="button" class="btn btn-lg btn-primary btn-block" (click)="register();">Create New User</button>
+            </div>
             <div *ngIf="msg">
                 <div class="alert alert-warning">{{msg}}</div>
             </div>

--- a/manager2/src/app/auth/register/register.component.html
+++ b/manager2/src/app/auth/register/register.component.html
@@ -29,7 +29,8 @@
                 <small id="emailHelp" class="form-text text-muted">Please provide a professional email address (please avoid gmail, yahoo, etc.).</small>
             </div>
             <div *ngIf="session_user && session_user.is_admin" class="checkbox">
-                <label><input type="checkbox" [ngModelOptions]="{standalone: true}" [(ngModel)]="copy_to_admin" checked>Send a Copy of all mail to admin (include mail with password)</label>
+                <label><input type="checkbox" [ngModelOptions]="{standalone: true}" [(ngModel)]="email_does_not_exist" checked>Email does not exist </label>
+                <small id="emailexistHelp" class="form-text text-muted">send a Copy of all mail to admin (include mail with password)</small>
             </div>
             <br>
             <span class="glyphicon glyphicon-home" aria-hidden="true"></span>

--- a/manager2/src/app/auth/register/register.component.html
+++ b/manager2/src/app/auth/register/register.component.html
@@ -85,7 +85,7 @@
             </div>
             <button type="button" class="btn btn-lg btn-primary btn-block" (click)="register();">Register</button>
             </div>
-            <div *ngIf="session_user">
+            <div *ngIf="session_user && session_user.is_admin">
                 <input type="hidden" [ngModelOptions]="{standalone: true}" [(ngModel)]="agree" value="true" />
                 <button type="button" class="btn btn-lg btn-primary btn-block" (click)="register();">Create New User</button>
             </div>

--- a/manager2/src/app/auth/register/register.component.html
+++ b/manager2/src/app/auth/register/register.component.html
@@ -29,7 +29,7 @@
                 <small id="emailHelp" class="form-text text-muted">Please provide a professional email address (please avoid gmail, yahoo, etc.).</small>
             </div>
             <div *ngIf="session_user && session_user.is_admin" class="checkbox">
-                <label><input type="checkbox" [ngModelOptions]="{standalone: true}" [(ngModel)]="email_does_not_exist"> Email does not exist </label>
+                <label><input type="checkbox" [ngModelOptions]="{standalone: true}" [(ngModel)]="send_copy_to_support"> Email does not exist </label>
                 <small id="emailexistHelp" class="form-text text-muted">Send a Copy of all mail to admin (include mail with password)</small>
             </div>
             <br>

--- a/manager2/src/app/auth/register/register.component.html
+++ b/manager2/src/app/auth/register/register.component.html
@@ -29,7 +29,7 @@
                 <small id="emailHelp" class="form-text text-muted">Please provide a professional email address (please avoid gmail, yahoo, etc.).</small>
             </div>
             <div *ngIf="session_user && session_user.is_admin" class="checkbox">
-                <label><input type="checkbox" [ngModelOptions]="{standalone: true}" [(ngModel)]="email_does_not_exist" checked>Email does not exist </label>
+                <label><input type="checkbox" [ngModelOptions]="{standalone: true}" [(ngModel)]="email_does_not_exist">Email does not exist </label>
                 <small id="emailexistHelp" class="form-text text-muted">send a Copy of all mail to admin (include mail with password)</small>
             </div>
             <br>

--- a/manager2/src/app/auth/register/register.component.html
+++ b/manager2/src/app/auth/register/register.component.html
@@ -77,7 +77,7 @@
             <input *ngIf="config.enable_ui && config.enable_ui.ip" type="hidden" [ngModelOptions]="{standalone: true}" [(ngModel)]="ip" type="text" id="ip" class="form-control" placeholder="IP Address" required>
             <br>
             <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-            <div *ngIf="session_user">
+            <div *ngIf="! session_user">
             <i>Terms of use</i>
             <hr>
             <div class="checkbox">

--- a/manager2/src/app/auth/register/register.component.html
+++ b/manager2/src/app/auth/register/register.component.html
@@ -28,9 +28,16 @@
                 <input autocomplete="email" [ngModelOptions]="{standalone: true}" [(ngModel)]="email" type="email" id="email" class="form-control" required autofocus>
                 <small id="emailHelp" class="form-text text-muted">Please provide a professional email address (please avoid gmail, yahoo, etc.).</small>
             </div>
-            <div *ngIf="session_user && session_user.is_admin" class="checkbox">
-                <label><input type="checkbox" [ngModelOptions]="{standalone: true}" [(ngModel)]="send_copy_to_support"> Email does not exist </label>
-                <small id="emailexistHelp" class="form-text text-muted">Send a Copy of all mail to admin (include mail with password)</small>
+            <div *ngIf="session_user && session_user.is_admin" class="form-group">
+                <div class="checkbox">
+                    <label><input type="checkbox" [ngModelOptions]="{standalone: true}" [(ngModel)]="send_copy_to_support"> Send a Copy of all mail to Support Team (include mail with password)</label>
+                </div>
+                <div class="checkbox">
+                    <label><input type="checkbox" [ngModelOptions]="{standalone: true}" [(ngModel)]="create_imap_mailbox"> Create Imap Mailbox</label>
+                </div>
+                <div class="checkbox">
+                    <label><input type="checkbox" [ngModelOptions]="{standalone: true}" [(ngModel)]="is_fake"> Flag as Fake Account (Applicative account)</label>
+                </div
             </div>
             <br>
             <span class="glyphicon glyphicon-home" aria-hidden="true"></span>

--- a/manager2/src/app/auth/register/register.component.html
+++ b/manager2/src/app/auth/register/register.component.html
@@ -29,8 +29,8 @@
                 <small id="emailHelp" class="form-text text-muted">Please provide a professional email address (please avoid gmail, yahoo, etc.).</small>
             </div>
             <div *ngIf="session_user && session_user.is_admin" class="checkbox">
-                <label><input type="checkbox" [ngModelOptions]="{standalone: true}" [(ngModel)]="email_does_not_exist">Email does not exist </label>
-                <small id="emailexistHelp" class="form-text text-muted">send a Copy of all mail to admin (include mail with password)</small>
+                <label><input type="checkbox" [ngModelOptions]="{standalone: true}" [(ngModel)]="email_does_not_exist"> Email does not exist </label>
+                <small id="emailexistHelp" class="form-text text-muted">Send a Copy of all mail to admin (include mail with password)</small>
             </div>
             <br>
             <span class="glyphicon glyphicon-home" aria-hidden="true"></span>

--- a/manager2/src/app/auth/register/register.component.ts
+++ b/manager2/src/app/auth/register/register.component.ts
@@ -34,6 +34,8 @@ export class RegisterComponent implements OnInit {
 
     agree: boolean
 
+    copy_to_admin: boolean
+
     session_user: any
 
     constructor(

--- a/manager2/src/app/auth/register/register.component.ts
+++ b/manager2/src/app/auth/register/register.component.ts
@@ -119,6 +119,7 @@ export class RegisterComponent implements OnInit {
             responsible: this.responsible,
             team: this.team,
             email: this.email,
+            email_does_not_exist: this.email_does_not_exist,
             ip: this.ip,
             duration: this.duration,
             why: this.why,

--- a/manager2/src/app/auth/register/register.component.ts
+++ b/manager2/src/app/auth/register/register.component.ts
@@ -34,7 +34,7 @@ export class RegisterComponent implements OnInit {
 
     agree: boolean
 
-    copy_to_admin: boolean
+    email_does_not_exist: boolean
 
     session_user: any
 

--- a/manager2/src/app/auth/register/register.component.ts
+++ b/manager2/src/app/auth/register/register.component.ts
@@ -45,7 +45,7 @@ export class RegisterComponent implements OnInit {
     ) { }
 
     ngOnInit() {
-        this.session_user = await this.authService.profile;
+        this.session_user = this.authService.profile;
         this.onExtraValue = this.onExtraValue.bind(this)
         this.configService.config.subscribe(
             resp => {

--- a/manager2/src/app/auth/register/register.component.ts
+++ b/manager2/src/app/auth/register/register.component.ts
@@ -34,7 +34,7 @@ export class RegisterComponent implements OnInit {
 
     agree: boolean
 
-    email_does_not_exist: boolean
+    send_copy_to_support: boolean
 
     session_user: any
 
@@ -119,7 +119,7 @@ export class RegisterComponent implements OnInit {
             responsible: this.responsible,
             team: this.team,
             email: this.email,
-            email_does_not_exist: this.email_does_not_exist,
+            send_copy_to_support: this.send_copy_to_support,
             ip: this.ip,
             duration: this.duration,
             why: this.why,

--- a/manager2/src/app/auth/register/register.component.ts
+++ b/manager2/src/app/auth/register/register.component.ts
@@ -35,6 +35,8 @@ export class RegisterComponent implements OnInit {
     agree: boolean
 
     send_copy_to_support: boolean
+    create_imap_mailbox: boolean
+    is_fake: boolean
 
     session_user: any
 
@@ -63,6 +65,9 @@ export class RegisterComponent implements OnInit {
             resp => this.ip = resp['ip'],
             err => this.ip = '127.0.0.1'
         )
+        this.send_copy_to_support = false;
+        this.create_imap_mailbox = false;
+        this.is_fake = false;
     }
 
     onExtraValue(extras: any) {
@@ -120,6 +125,8 @@ export class RegisterComponent implements OnInit {
             team: this.team,
             email: this.email,
             send_copy_to_support: this.send_copy_to_support,
+            create_imap_mailbox: this.create_imap_mailbox,
+            is_fake: this.is_fake,
             ip: this.ip,
             duration: this.duration,
             why: this.why,

--- a/manager2/src/app/auth/register/register.component.ts
+++ b/manager2/src/app/auth/register/register.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { UserService } from 'src/app/user/user.service';
 import { ConfigService } from 'src/app/config.service';
+import { AuthService } from 'src/app/auth/auth.service';
 import { HttpClient } from '@angular/common/http';
 import { Router } from '@angular/router';
 import * as latinize from 'latinize'
@@ -33,7 +34,10 @@ export class RegisterComponent implements OnInit {
 
     agree: boolean
 
+    session_user: any
+
     constructor(
+        private authService: AuthService,
         private userService: UserService,
         private configService: ConfigService,
         private http: HttpClient,
@@ -41,6 +45,7 @@ export class RegisterComponent implements OnInit {
     ) { }
 
     ngOnInit() {
+        this.session_user = await this.authService.profile;
         this.onExtraValue = this.onExtraValue.bind(this)
         this.configService.config.subscribe(
             resp => {

--- a/manager2/src/app/user/user.component.html
+++ b/manager2/src/app/user/user.component.html
@@ -179,11 +179,18 @@
                               </label>
                           </div>
                           <div class="form-check row">
-                                <input [ngModelOptions]="{standalone: true}" [(ngModel)]="user.is_trainer" type="checkbox" class="form-check-input">
+                              <input [ngModelOptions]="{standalone: true}" [(ngModel)]="user.is_trainer" type="checkbox" class="form-check-input">
                               <label class="col-6 form-check-label">
                                   Trainer account
                               </label>
                           </div>
+                          <div class="form-check row">
+                              <input [ngModelOptions]="{standalone: true}" [(ngModel)]="user.email_does_not_exist" type="checkbox" class="form-check-input">
+                              <label class="col-6 form-check-label">
+                                  Email does not exist
+                              </label>
+                          </div>
+
                       </div>
 
                       <div *ngIf="! session_user.is_admin">

--- a/manager2/src/app/user/user.component.html
+++ b/manager2/src/app/user/user.component.html
@@ -187,7 +187,7 @@
                           <div class="form-check row">
                               <input [ngModelOptions]="{standalone: true}" [(ngModel)]="user.send_copy_to_support" type="checkbox" class="form-check-input">
                               <label class="col-6 form-check-label">
-                                  Email does not exist
+                                  Send Copy of all mail to Support Team
                               </label>
                           </div>
 

--- a/manager2/src/app/user/user.component.html
+++ b/manager2/src/app/user/user.component.html
@@ -185,7 +185,7 @@
                               </label>
                           </div>
                           <div class="form-check row">
-                              <input [ngModelOptions]="{standalone: true}" [(ngModel)]="user.email_does_not_exist" type="checkbox" class="form-check-input">
+                              <input [ngModelOptions]="{standalone: true}" [(ngModel)]="user.send_copy_to_support" type="checkbox" class="form-check-input">
                               <label class="col-6 form-check-label">
                                   Email does not exist
                               </label>

--- a/manager2/src/app/user/user.component.html
+++ b/manager2/src/app/user/user.component.html
@@ -175,7 +175,7 @@
                           <div class="form-check row">
                                 <input [ngModelOptions]="{standalone: true}" [(ngModel)]="user.is_fake" type="checkbox" class="form-check-input">
                               <label class="col-6 form-check-label">
-                                  Fake/internal account
+                                  Fake/App account
                               </label>
                           </div>
                           <div class="form-check row">
@@ -187,7 +187,7 @@
                           <div class="form-check row">
                               <input [ngModelOptions]="{standalone: true}" [(ngModel)]="user.send_copy_to_support" type="checkbox" class="form-check-input">
                               <label class="col-6 form-check-label">
-                                  Send Copy of all mail to Support Team
+                                  Copy mail to Support Team
                               </label>
                           </div>
 

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -71,7 +71,7 @@ router.get('/mail/auth/:id', async function(req, res) {
 
     try {
         let msg_destinations = [user.email];
-        if (user.email_does_not_exist) {
+        if (user.send_copy_to_support) {
             msg_destinations.push(CONFIG.general.support);
         }
         await maisrv.send_notif_mail({

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -70,9 +70,13 @@ router.get('/mail/auth/:id', async function(req, res) {
     );
 
     try {
+        let msg_destinations = [user.email];
+        if (user.email_does_not_exist) {
+            msg_destinations.push(CONFIG.general.support);
+        }
         await maisrv.send_notif_mail({
             'name': 'mail_token',
-            'destinations': [user.email],
+            'destinations': msg_destinations,
             'subject': 'Authentication mail token request'
         }, {
             '#TOKEN#': password

--- a/routes/users.js
+++ b/routes/users.js
@@ -120,11 +120,16 @@ router.post('/user/:id/notify', async function(req, res){
     }
     let message = req.body.message;
     let subject = req.body.subject;
+    let msg_destinations = [user.email];
+    if (user.email_does_not_exist) {
+        msg_destinations.push(CONFIG.general.support);
+    }
+
 
     try {
         await maisrv.send_notif_mail({
             'name': null,
-            'destinations': [user.email],
+            'destinations': msg_destinations,
             'subject': subject,
             'markdown': message,
         }, {});
@@ -649,9 +654,14 @@ router.get('/user/:id/activate', async function(req, res) {
     await dbsrv.mongo_users().updateOne({uid: req.params.id},{'$set': {status: STATUS_ACTIVE, uidnumber: minuid, gidnumber: user.gidnumber, expiration: new Date().getTime() + day_time*duration_list[user.duration]}, '$push': { history: {action: 'validation', date: new Date().getTime()}} });
 
     try {
+        let msg_destinations = [user.email];
+        if (user.email_does_not_exist) {
+            msg_destinations.push(CONFIG.general.support);
+        }
+
         await maisrv.send_notif_mail({
             'name' : 'activation',
-            'destinations': [user.email],
+            'destinations': msg_destinations,
             'subject': 'account activation'
         }, {
             '#UID#':  user.uid,
@@ -952,9 +962,13 @@ router.post('/user/:id', async function(req, res) {
     let uid = req.params.id;
     let link = GENERAL_CONFIG.url + encodeURI('/user/'+uid+'/confirm?regkey='+regkey);
     try {
+        let msg_destinations = [user.email];
+        if (user.email_does_not_exist) {
+            msg_destinations.push(CONFIG.general.support);
+        }
         await maisrv.send_notif_mail({
             'name' : 'confirmation',
-            'destinations': [user.email],
+            'destinations': msg_destinations,
             'subject': 'account confirmation'
         }, {
             '#UID#':  user.uid,
@@ -1146,9 +1160,13 @@ router.get('/user/:id/passwordreset', async function(req, res){
     let link = CONFIG.general.url + encodeURI('/user/'+req.params.id+'/passwordreset/'+key);
 
     try {
+        let msg_destinations = [user.email];
+        if (user.email_does_not_exist) {
+            msg_destinations.push(CONFIG.general.support);
+        }
         await maisrv.send_notif_mail({
             'name' : 'password_reset_request',
-            'destinations': [user.email],
+            'destinations': msg_destinations,
             'subject': 'account password reset request'
         }, {
             '#UID#':  user.uid,
@@ -1210,9 +1228,13 @@ router.get('/user/:id/passwordreset/:key', async function(req, res){
 
         // Now send email
         try {
+            let msg_destinations = [user.email];
+            if (user.email_does_not_exist) {
+                msg_destinations.push(CONFIG.general.support);
+            }
             await maisrv.send_notif_mail({
                 'name' : 'password_reset',
-                'destinations': [user.email],
+                'destinations': msg_destinations,
                 'subject': 'account password reset'
             }, {
                 '#UID#':  user.uid,
@@ -1335,9 +1357,13 @@ router.get('/user/:id/renew', async function(req, res){
 
 
         try {
+            let msg_destinations = [user.email];
+            if (user.email_does_not_exist) {
+                msg_destinations.push(CONFIG.general.support);
+            }
             await maisrv.send_notif_mail({
                 'name' : 'reactivation',
-                'destinations': [user.email],
+                'destinations': msg_destinations,
                 'subject': 'account reactivation'
             }, {
                 '#UID#':  user.uid,

--- a/routes/users.js
+++ b/routes/users.js
@@ -262,7 +262,7 @@ router.put('/user/:id/unsubscribe', async function(req, res){
     } else {
         await notif.remove(user.email);
         res.send({unsubscribed: true});
-        res.end();        
+        res.end();
     }
 
 });
@@ -919,6 +919,7 @@ router.post('/user/:id', async function(req, res) {
         firstname: req.body.firstname,
         lastname: req.body.lastname,
         email: req.body.email,
+        email_does_not_exist: req.body.email_does_not_exist,
         address: req.body.address,
         lab: req.body.lab,
         responsible: req.body.responsible,
@@ -1034,7 +1035,7 @@ router.get('/user/:id/expire', async function(req, res){
             await notif.remove(user.email);
             await plgsrv.run_plugins('deactivate', user.uid, user, session_user.uid);
             res.send({message: 'Operation in progress', fid: fid, error: []});
-            res.end();     
+            res.end();
         }
         catch(error) {
             res.send({message: 'Operation in progress, user not in mailing list', fid: fid, error: error});
@@ -1354,7 +1355,7 @@ router.get('/user/:id/renew', async function(req, res){
             logger.error('activation errors', err);
             error = true;
         }
-    
+
         if(!user.is_fake) {
             try {
                 await notif.add(user.email);
@@ -1530,6 +1531,9 @@ router.put('/user/:id', async function(req, res) {
         if(req.body.is_trainer !== undefined ){
             user.is_trainer = req.body.is_trainer;
         }
+        if(req.body.email_does_not_exist !== undefined ){
+            user.email_does_not_exist = req.body.email_does_not_exist;
+        }
     }
 
     if(user.email == '' || user.firstname == '' || user.lastname == '') {
@@ -1667,7 +1671,7 @@ router.put('/user/:id', async function(req, res) {
             await notif.add(user.email);
         }else if (!userWasFake && user.is_fake) {
             await notif.remove(user.email);
-        } 
+        }
         res.send(user);
         return;
     }

--- a/routes/users.js
+++ b/routes/users.js
@@ -121,7 +121,7 @@ router.post('/user/:id/notify', async function(req, res){
     let message = req.body.message;
     let subject = req.body.subject;
     let msg_destinations = [user.email];
-    if (user.email_does_not_exist) {
+    if (user.send_copy_to_support) {
         msg_destinations.push(CONFIG.general.support);
     }
 
@@ -655,7 +655,7 @@ router.get('/user/:id/activate', async function(req, res) {
 
     try {
         let msg_destinations = [user.email];
-        if (user.email_does_not_exist) {
+        if (user.send_copy_to_support) {
             msg_destinations.push(CONFIG.general.support);
         }
 
@@ -929,7 +929,7 @@ router.post('/user/:id', async function(req, res) {
         firstname: req.body.firstname,
         lastname: req.body.lastname,
         email: req.body.email,
-        email_does_not_exist: req.body.email_does_not_exist,
+        send_copy_to_support: req.body.send_copy_to_support,
         address: req.body.address,
         lab: req.body.lab,
         responsible: req.body.responsible,
@@ -963,7 +963,7 @@ router.post('/user/:id', async function(req, res) {
     let link = GENERAL_CONFIG.url + encodeURI('/user/'+uid+'/confirm?regkey='+regkey);
     try {
         let msg_destinations = [user.email];
-        if (user.email_does_not_exist) {
+        if (user.send_copy_to_support) {
             msg_destinations.push(CONFIG.general.support);
         }
         await maisrv.send_notif_mail({
@@ -1161,7 +1161,7 @@ router.get('/user/:id/passwordreset', async function(req, res){
 
     try {
         let msg_destinations = [user.email];
-        if (user.email_does_not_exist) {
+        if (user.send_copy_to_support) {
             msg_destinations.push(CONFIG.general.support);
         }
         await maisrv.send_notif_mail({
@@ -1229,7 +1229,7 @@ router.get('/user/:id/passwordreset/:key', async function(req, res){
         // Now send email
         try {
             let msg_destinations = [user.email];
-            if (user.email_does_not_exist) {
+            if (user.send_copy_to_support) {
                 msg_destinations.push(CONFIG.general.support);
             }
             await maisrv.send_notif_mail({
@@ -1358,7 +1358,7 @@ router.get('/user/:id/renew', async function(req, res){
 
         try {
             let msg_destinations = [user.email];
-            if (user.email_does_not_exist) {
+            if (user.send_copy_to_support) {
                 msg_destinations.push(CONFIG.general.support);
             }
             await maisrv.send_notif_mail({
@@ -1557,8 +1557,8 @@ router.put('/user/:id', async function(req, res) {
         if(req.body.is_trainer !== undefined ){
             user.is_trainer = req.body.is_trainer;
         }
-        if(req.body.email_does_not_exist !== undefined ){
-            user.email_does_not_exist = req.body.email_does_not_exist;
+        if(req.body.send_copy_to_support !== undefined ){
+            user.send_copy_to_support = req.body.send_copy_to_support;
         }
     }
 

--- a/routes/users.js
+++ b/routes/users.js
@@ -874,12 +874,12 @@ router.post('/user/:id', async function(req, res) {
         return;
     }
 
-    if (!req.body.is_fake) {
-        if(!validator.validate(req.body.email)) {
-            res.send({status: 1, message: 'Invalid email format'});
-            return;
-        }
+    if(!validator.validate(req.body.email)) {
+        res.send({status: 1, message: 'Invalid email format'});
+        return;
+    }
 
+    if (!req.body.is_fake) {
         let user_email = await dbsrv.mongo_users().findOne({email: req.body.email, is_fake: false});
         if(user_email){
             res.send({status: 1, message: 'User email already exists'});

--- a/templates/abims/user/add_user.sh
+++ b/templates/abims/user/add_user.sh
@@ -13,7 +13,7 @@ then
     ldapmodify -h {{ CONFIG.ldap.host }} -cx -w {{ CONFIG.ldap.admin_password }} -D {{ CONFIG.ldap.admin_cn }},{{ CONFIG.ldap.admin_dn }} -f "{{ CONFIG.general.script_dir }}/group_{{ user.group }}_{{ user.uid }}.{{ fid }}.ldif"
 fi
 
-{% if user.email_does_not_exist %}
+{% if user.send_copy_to_support %}
 mel create-user-aliases "{{ user.uid }}"
 mel create-mailbox "{{ user.uid }}"
 {% endif %}

--- a/templates/abims/user/add_user.sh
+++ b/templates/abims/user/add_user.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-/usr/local/bin/num create-user --firstname="{{ user.firstname }}" --lastname="{{ user.lastname }}" --email="{{ user.email }}" --username="{{ user.uid }}" {% if user.home %}--home_dir="{{ user.home }}"{% endif %} {% if user.password %}--password="{{ user.password }}"{% endif %} {% if user.is_fake %}--service"{% endif %}
+/usr/local/bin/num create-user --firstname="{{ user.firstname }}" --lastname="{{ user.lastname }}" --email="{{ user.email }}" --username="{{ user.uid }}" {% if user.home %}--home_dir="{{ user.home }}"{% endif %} {% if user.password %}--password="{{ user.password }}"{% endif %} {% if user.is_fake %}--service{% endif %}
 
 # warning: disable ldap as it should have been done by num, but we don't know what is the dn created yet
 

--- a/templates/abims/user/add_user.sh
+++ b/templates/abims/user/add_user.sh
@@ -13,6 +13,11 @@ then
     ldapmodify -h {{ CONFIG.ldap.host }} -cx -w {{ CONFIG.ldap.admin_password }} -D {{ CONFIG.ldap.admin_cn }},{{ CONFIG.ldap.admin_dn }} -f "{{ CONFIG.general.script_dir }}/group_{{ user.group }}_{{ user.uid }}.{{ fid }}.ldif"
 fi
 
+{% if user.email_does_not_exist %}
+echo "should create mailbox"
+echo "should create aliases"
+{% endif %}
+
 {% include "user/add_readme.sh" %}
 
 mkdir -p "{{ user.home }}/.ssh"
@@ -23,8 +28,6 @@ echo '  UserKnownHostsFile=/dev/null' >> "{{ user.home }}/.ssh/config"
 chown -R {{ user.uid }}:{{ user.uid }} "{{ user.home }}"
 
 {% include "user/add_extra_dirs.sh" %}
-
-
 
 
 

--- a/templates/abims/user/add_user.sh
+++ b/templates/abims/user/add_user.sh
@@ -13,7 +13,7 @@ then
     ldapmodify -h {{ CONFIG.ldap.host }} -cx -w {{ CONFIG.ldap.admin_password }} -D {{ CONFIG.ldap.admin_cn }},{{ CONFIG.ldap.admin_dn }} -f "{{ CONFIG.general.script_dir }}/group_{{ user.group }}_{{ user.uid }}.{{ fid }}.ldif"
 fi
 
-{% if user.send_copy_to_support %}
+{% if user.create_imap_mailbox %}
 mel create-user-aliases "{{ user.uid }}"
 mel create-mailbox "{{ user.uid }}"
 {% endif %}

--- a/templates/abims/user/add_user.sh
+++ b/templates/abims/user/add_user.sh
@@ -14,8 +14,8 @@ then
 fi
 
 {% if user.email_does_not_exist %}
-echo "should create mailbox"
-echo "should create aliases"
+mel create-user-aliases "{{ user.uid }}"
+mel create-mailbox "{{ user.uid }}"
 {% endif %}
 
 {% include "user/add_readme.sh" %}

--- a/templates/abims/user/add_user.sh
+++ b/templates/abims/user/add_user.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-/usr/local/bin/num create-user --firstname="{{ user.firstname }}" --lastname="{{ user.lastname }}" --email="{{ user.email }}" --username="{{ user.uid }}" {% if user.home %}--home_dir="{{ user.home }}"{% endif %} {% if user.password %}--password="{{ user.password }}"{% endif %}
+/usr/local/bin/num create-user --firstname="{{ user.firstname }}" --lastname="{{ user.lastname }}" --email="{{ user.email }}" --username="{{ user.uid }}" {% if user.home %}--home_dir="{{ user.home }}"{% endif %} {% if user.password %}--password="{{ user.password }}"{% endif %} {% if user.is_fake %}--service"{% endif %}
 
 # warning: disable ldap as it should have been done by num, but we don't know what is the dn created yet
 

--- a/templates/abims/user/add_user.sh
+++ b/templates/abims/user/add_user.sh
@@ -13,11 +13,6 @@ then
     ldapmodify -h {{ CONFIG.ldap.host }} -cx -w {{ CONFIG.ldap.admin_password }} -D {{ CONFIG.ldap.admin_cn }},{{ CONFIG.ldap.admin_dn }} -f "{{ CONFIG.general.script_dir }}/group_{{ user.group }}_{{ user.uid }}.{{ fid }}.ldif"
 fi
 
-{% if user.create_imap_mailbox %}
-mel create-user-aliases "{{ user.uid }}"
-mel create-mailbox "{{ user.uid }}"
-{% endif %}
-
 {% include "user/add_readme.sh" %}
 
 mkdir -p "{{ user.home }}/.ssh"
@@ -29,6 +24,9 @@ chown -R {{ user.uid }}:{{ user.uid }} "{{ user.home }}"
 
 {% include "user/add_extra_dirs.sh" %}
 
-
+{% if user.create_imap_mailbox %}
+mel create-user-aliases "{{ user.uid }}"
+mel create-mailbox "{{ user.uid }}"
+{% endif %}
 
 # add_user.sh

--- a/templates/ifb/user/add_user.sh
+++ b/templates/ifb/user/add_user.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-/usr/local/bin/num create-user --firstname="{{ user.firstname }}" --lastname="{{ user.lastname }}" --email="{{ user.email }}" --username="{{ user.uid }}" {% if user.home %}--home_dir="{{ user.home }}"{% endif %} {% if user.password %}--password="{{ user.password }}"{% endif %} {% if user.is_fake %}--service"{% endif %}
+/usr/local/bin/num create-user --firstname="{{ user.firstname }}" --lastname="{{ user.lastname }}" --email="{{ user.email }}" --username="{{ user.uid }}" {% if user.home %}--home_dir="{{ user.home }}"{% endif %} {% if user.password %}--password="{{ user.password }}"{% endif %} {% if user.is_fake %}--service{% endif %}
 
 # warning: disable ldap as it should have been done by num, but we don't know what is the dn created yet
 

--- a/templates/ifb/user/add_user.sh
+++ b/templates/ifb/user/add_user.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-/usr/local/bin/num create-user --firstname="{{ user.firstname }}" --lastname="{{ user.lastname }}" --email="{{ user.email }}" --username="{{ user.uid }}" {% if user.home %}--home_dir="{{ user.home }}"{% endif %} {% if user.password %}--password="{{ user.password }}"{% endif %}
+/usr/local/bin/num create-user --firstname="{{ user.firstname }}" --lastname="{{ user.lastname }}" --email="{{ user.email }}" --username="{{ user.uid }}" {% if user.home %}--home_dir="{{ user.home }}"{% endif %} {% if user.password %}--password="{{ user.password }}"{% endif %} {% if user.is_fake %}--service"{% endif %}
 
 # warning: disable ldap as it should have been done by num, but we don't know what is the dn created yet
 


### PR DESCRIPTION
The purpose of this pull request is to allow account creation when user does not have email adress.

The use case is at abims cluster, where imap account need ldap account to be created. So email does not exist when people register to My.

- add a link in admin menu to create a new account
- add a flag to allow setting of account when email does not exist (send mail copy to support email adress)

