### PR TITLE
Feature disallow expiration extend

### DIFF
--- a/config/default.json.template
+++ b/config/default.json.template
@@ -9,6 +9,7 @@
         "source_folder" : "/folder/with/readme2/"
       }
     ],
+    "allow_extend": true,
     "prevent_reuse": true,
     "terms_of_use": "/doc/terms_of_use.txt",
     "web_home" : "user",

--- a/cron/expire.js
+++ b/cron/expire.js
@@ -75,7 +75,19 @@ dbsrv.init_db().then(async () => {
 
         }
         user.history.push({'action': 'expire', date: new Date().getTime()});
-        await dbsrv.mongo_users().updateOne({uid: user.uid},{'$set': {status: STATUS_EXPIRED, expiration: new Date().getTime(), history: user.history}});
+        await dbsrv.mongo_users().updateOne(
+            {
+                uid: user.uid
+            },
+            {
+                '$set': {
+                    status: STATUS_EXPIRED,
+                    expiration: new Date().getTime(),
+                    history: user.history,
+                    expiration_notif: 0
+                }
+            }
+        );
         try {
             let created_file = await filer.user_expire_user(user, fid);
             console.log('File Created: ', created_file);

--- a/cron/gomngr.sh
+++ b/cron/gomngr.sh
@@ -105,14 +105,14 @@ while true; do
   if [ $NOW -gt $NEXTMONTH ]; then
     echo "${NOW}: time for monthly tasks"
     NEXTMONTH=`date --date="$(date +'%Y-%m-01') + 1 month 05:00:00" +%s`
-    echo "Check for account upcoming expiration"
-    /opt/crontask.sh test_expiration
-    if [ $EXIT_REQUEST -eq 1 ]; then
-      rm /tmp/gomngr.lock
-      rm /tmp/gomngr.list
-      echo "Exit requested"
-      exit 0
-    fi
+    #echo "Check for account upcoming expiration"
+    #/opt/crontask.sh test_expiration
+    #if [ $EXIT_REQUEST -eq 1 ]; then
+    #  rm /tmp/gomngr.lock
+    #  rm /tmp/gomngr.list
+    #  echo "Exit requested"
+    #  exit 0
+    #fi
     echo "Check for account expiration"
     /opt/crontask.sh expire
     if [ $EXIT_REQUEST -eq 1 ]; then
@@ -123,8 +123,10 @@ while true; do
     fi
   fi
   if [ $NOW -gt $TOMORROW ]; then
-    echo "Check for reservation removal"
+    echo "${NOW}: time for daily tasks"
     TOMORROW=`date --date="1 day 05:00:00" +%s`
+
+    echo "Check for reservation removal"
     /opt/crontask.sh reservation_remove
     if [ $EXIT_REQUEST -eq 1 ]; then
       rm /tmp/gomngr.lock
@@ -134,6 +136,14 @@ while true; do
     fi
     echo "Check for reservation creation"
     /opt/crontask.sh reservation_create
+    if [ $EXIT_REQUEST -eq 1 ]; then
+      rm /tmp/gomngr.lock
+      rm /tmp/gomngr.list
+      echo "Exit requested"
+      exit 0
+    fi
+    echo "Check for account upcoming expiration"
+    /opt/crontask.sh test_expiration
     if [ $EXIT_REQUEST -eq 1 ]; then
       rm /tmp/gomngr.lock
       rm /tmp/gomngr.list

--- a/cron/test_expiration.js
+++ b/cron/test_expiration.js
@@ -66,8 +66,12 @@ dbsrv.init_db().then(async ()=>{
             continue;
         }
         console.log(`User will expire, send notication number ${user.expiration_notif} to ${user.uid}`);
+
         let link = CONFIG.general.url +
             encodeURI('/user/'+user.uid+'/renew/'+user.regkey);
+        if (CONFIG.general.allow_extend === false) {
+            link = CONFIG.general.support;
+        }
         try {
             await maisrv.send_notif_mail({
                 'name': 'expiration',

--- a/manager2/src/app/user/user.component.html
+++ b/manager2/src/app/user/user.component.html
@@ -12,7 +12,7 @@
           <button *ngIf="session_user.is_admin && (user.status == STATUS_PENDING_APPROVAL || user.status == STATUS_PENDING_EMAIL)" class="btn btn-success" (click)="activate()">Activate</button>
           <div *ngIf="session_user.is_admin && (user.status == STATUS_PENDING_APPROVAL || user.status == STATUS_PENDING_EMAIL)"><app-my-delete-confirm [onConfirm]="delete" [data]="" [explainMessage]="true"></app-my-delete-confirm></div>
           <button *ngIf="session_user.is_admin && user.status == STATUS_ACTIVE" class="btn btn-warning" (click)="expire()">Expire</button>
-          <button *ngIf="user.status == STATUS_ACTIVE" class="btn btn-success" (click)="extend()">Extend validity</button>
+          <button *ngIf="config.allow_extend && user.status == STATUS_ACTIVE" class="btn btn-success" (click)="extend()">Extend validity</button>
           <button *ngIf="session_user.is_admin && user.status == STATUS_EXPIRED" class="btn btn-success" (click)="renew()">Renew</button>
           <div *ngIf="session_user.is_admin && user.status == STATUS_EXPIRED"><app-my-delete-confirm [onConfirm]="delete" [data]="" [explainMessage]="true"></app-my-delete-confirm></div>
       </div>

--- a/routes/conf.js
+++ b/routes/conf.js
@@ -26,6 +26,7 @@ router.get('/conf', async function(req, res){
         'duration': Object.keys(my_conf.duration),
         'project': my_conf.project,
         'registration': my_conf.registration || [],
+        'allow_extend': my_conf.general.allow_extend===false?  my_conf.general.allow_extend: true
     };
 
     // should be check on each call

--- a/routes/users.js
+++ b/routes/users.js
@@ -1283,6 +1283,26 @@ router.get('/user/:id/renew/:regkey', async function(req, res){
         res.status(403).send({message: 'Invalid parameters'});
         return;
     }
+
+    if (GENERAL_CONFIG.allow_extend === false) {
+        let session_user = null;
+        let isadmin = false;
+        try {
+            session_user = await dbsrv.mongo_users().findOne({_id: req.locals.logInfo.id});
+            isadmin = await rolsrv.is_admin(session_user);
+            if(!isadmin) {
+                res.status(403).send({message: 'not allowed'});
+                res.end();
+                return;
+            }
+        } catch(e) {
+            logger.error(e);
+            res.status(403).send({message: 'not allowed'});
+            res.end();
+            return;
+        }
+    }
+
     let user = await dbsrv.mongo_users().findOne({uid: req.params.id});
     if(!user){
         res.status(404).send({message: 'User not found'});

--- a/routes/users.js
+++ b/routes/users.js
@@ -651,7 +651,18 @@ router.get('/user/:id/activate', async function(req, res) {
         return;
     }
 
-    await dbsrv.mongo_users().updateOne({uid: req.params.id},{'$set': {status: STATUS_ACTIVE, uidnumber: minuid, gidnumber: user.gidnumber, expiration: new Date().getTime() + day_time*duration_list[user.duration]}, '$push': { history: {action: 'validation', date: new Date().getTime()}} });
+    await dbsrv.mongo_users().updateOne({uid: req.params.id},{
+        '$set': {
+            status: STATUS_ACTIVE,
+            uidnumber: minuid,
+            gidnumber: user.gidnumber,
+            expiration: new Date().getTime() + day_time*duration_list[user.duration],
+            expiration_notif: 0
+        },
+        '$push': {
+            history: {action: 'validation', date: new Date().getTime()}
+        }
+    });
 
     try {
         let msg_destinations = [user.email];


### PR DESCRIPTION
add allow_extend option in config (default=true)
    
this option can prevent a user to extend himself his account expiration date before expiration.
    User will still receive emails, but no button nor link to extend


To see if this option is really needed/wanted