### PR TITLE
ABiMS - Fix quota

### DIFF
--- a/templates/abims/project/add_project.sh
+++ b/templates/abims/project/add_project.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-/usr/local/bin/num create-project {{ project.id }}
+/usr/local/bin/num create-project {{ project.id }} -sq {{ project.size }}GB
 
 # Disable because it's not the same command to create a quota and modify/apply it
 # @TODO add template in num to allow modifying quota


### PR DESCRIPTION
So we disable the `set_quota` because `create-project` already set a quota and the command isn't the same for creating and modify.

But we should at least set the quota once via `create-project` 😉 