### PR TITLE
add template directory for ifb-core

### DIFF
--- a/templates/ifb-core/templates.json
+++ b/templates/ifb-core/templates.json
@@ -1,0 +1,1 @@
+../default/templates.json


### PR DESCRIPTION
it will be used by ifb-core to manage access to wordpress access for the ifb website and other intranet tool for ifb core team.

it is not related to ifb cluster