### PR TITLE
Better error management when logging in

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "master"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "githubPullRequests.ignoredPullRequestBranches": [
-        "master"
-    ]
-}

--- a/manager2/src/app/auth/auth.service.ts
+++ b/manager2/src/app/auth/auth.service.ts
@@ -29,7 +29,7 @@ export class AuthService {
                 { observe: 'response' }).subscribe(
                     resp => {
                         if(! resp.body['user']) {
-                            reject({'error': resp.body['message']});
+                            reject({'error': {'message': resp.body['message']}});
                             return;
                         }
 

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -479,7 +479,7 @@ router.post('/auth/:id', async function(req, res) {
             }
             attemps[user.uid]['attemps'] += 1;
             attemps[user.uid]['last'] = new Date();
-            res.status(401).send({user: null, message: 'Login error, remains ' + (3-attemps[user.uid]['attemps']) + ' attemps.'});
+            res.status(401).send({message: 'Login error, remains ' + (3-attemps[user.uid]['attemps']) + ' attemps.'});
             res.end();
             return;
         }

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -473,7 +473,7 @@ router.post('/auth/:id', async function(req, res) {
             }
             attemps[user.uid]['attemps'] += 1;
             attemps[user.uid]['last'] = new Date();
-            res.send({user: null, message: 'Login error, remains ' + (3-attemps[user.uid]['attemps']) + ' attemps.'});
+            res.status(401).send({user: null, message: 'Login error, remains ' + (3-attemps[user.uid]['attemps']) + ' attemps.'});
             res.end();
             return;
         }

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -377,6 +377,12 @@ router.post('/auth/:id', async function(req, res) {
         res.status(404).send({message: 'User not found'});
         return;
     }
+
+    if(user.status == STATUS_EXPIRED){
+        res.status(401).send({message: 'Your account is expired, please contact the support for reactivation at '+GENERAL_CONFIG.support});
+        return;
+    }
+
     let usertoken = jwt.sign(
         { user: user._id, isLogged: true, u2f: user._id },
         CONFIG.general.secret,


### PR DESCRIPTION
Should close #365 

As of now, 'wrong password' error are not properly managed (no message shown), due to

* Returning the error with a 200 code instead of 40X (other errors codes are managed)
* No properly managing incorrect 200 response

Also added the check for expired account
