### PR TITLE
Add the possibility to give feedback to users based on their choice

### DIFF
--- a/config/test.json
+++ b/config/test.json
@@ -46,6 +46,12 @@
    "multiple": false
    },
    {
+    "title": "second choice with feedback",
+    "choices": [["c7", "choice4", "alert-success", "Positive feedback"], ["c8", "choice5", "alert-warning", "Mixed feedback"], ["c9", "choice6", "alert-danger", "Negative feedback"]],
+    "multiple": false
+    },
+  
+   {
      "title": "extra data",
      "choices": [["cc4", "choice4"], ["cc5", "choice5"], ["cc6", "choice6"]],
      "multiple": false

--- a/config/test.json
+++ b/config/test.json
@@ -35,10 +35,20 @@
  },
  "registration": [
   {
-    "title": "Ethical and legal aspect of your data",
-    "description": "Ethical and legal aspect of your data",
-    "choices": [["c1","Public data"], ["c2", "Confidential data"], ["c3", "Personal data"], ["c4", "Sensitive data"]],
-    "multiple": false
+    "title": "first choice",
+    "description": "this is truc and bla bla bla",
+    "choices": [["c1","choice1"], ["c2", "choice2"], ["c3", "choice3"]],
+    "multiple": true
+   },
+   {
+   "title": "second choice",
+   "choices": [["c4", "choice4"], ["c5", "choice5"], ["c6", "choice6"]],
+   "multiple": false
+   },
+   {
+     "title": "extra data",
+     "choices": [["cc4", "choice4"], ["cc5", "choice5"], ["cc6", "choice6"]],
+     "multiple": false
    }
     
  ],

--- a/config/test.json
+++ b/config/test.json
@@ -34,22 +34,13 @@
     "plugin_script_dir": "/opt/my/plugin-scripts"
  },
  "registration": [
-    {
-     "title": "first choice",
-     "description": "this is truc and bla bla bla",
-     "choices": [["c1","choice1"], ["c2", "choice2"], ["c3", "choice3"]],
-     "multiple": true
-    },
-    {
-    "title": "second choice",
-    "choices": [["c4", "choice4"], ["c5", "choice5"], ["c6", "choice6"]],
+  {
+    "title": "Ethical and legal aspect of your data",
+    "description": "Ethical and legal aspect of your data",
+    "choices": [["c1","Public data"], ["c2", "Confidential data"], ["c3", "Personal data"], ["c4", "Sensitive data"]],
     "multiple": false
-    },
-    {
-      "title": "extra data",
-      "choices": [["cc4", "choice4"], ["cc5", "choice5"], ["cc6", "choice6"]],
-      "multiple": false
-    }
+   }
+    
  ],
  "enable_ui": {
      "messages": true,

--- a/config/test.json
+++ b/config/test.json
@@ -46,12 +46,6 @@
    "multiple": false
    },
    {
-    "title": "second choice with feedback",
-    "choices": [["c7", "choice4", "alert-success", "Positive feedback"], ["c8", "choice5", "alert-warning", "Mixed feedback"], ["c9", "choice6", "alert-danger", "Negative feedback"]],
-    "multiple": false
-    },
-  
-   {
      "title": "extra data",
      "choices": [["cc4", "choice4"], ["cc5", "choice5"], ["cc6", "choice6"]],
      "multiple": false

--- a/config/test.json
+++ b/config/test.json
@@ -46,6 +46,13 @@
    "multiple": false
    },
    {
+    "title": "second choice with feedback",
+    "choices": [["c7", "choice4", "alert-success", "Positive feedback"], ["c8", "choice5", "alert-warning", "Mixed feedback"], ["c9", "choice6", "alert-danger", "Negative feedback"]],
+    "multiple": false,
+    "feedback": true
+    },
+  
+   {
      "title": "extra data",
      "choices": [["cc4", "choice4"], ["cc5", "choice5"], ["cc6", "choice6"]],
      "multiple": false

--- a/manager2/src/app/user/user-extra.component.html
+++ b/manager2/src/app/user/user-extra.component.html
@@ -19,10 +19,14 @@
     <div *ngIf="!extra.multiple">
      <div class="form-extra-title">{{extra.description || extra.title}}</div>
         <div *ngFor="let choice of extra.choices">
-        <input type="radio" class="form-check-input" (change)="extraChange(extra.title, $event)" [checked]="extra.value==choice[0]" [value]="choice[0]" [name]="extra.title">
-        <label class="form-check-label" data-toggle="tooltip" data-placement="bottom" title="tooltip on radio!">
+        <input type="radio" class="form-check-input" (change)="extraChange(extra.title, $event)" [checked]="extra.value==choice[0]" [value]="choice[0]" [name]="extra.title" data-toggle="alert" data-placement="bottom" title="tooltip on radio!">
+        <label class="form-check-label">
             {{choice[1]}}
         </label>
+        <div *ngIf="extra.responsive">
+ <div class="alert {{choice[2]}}" role="alert" *ngIf="extra.value == choice[0]">{{choice[3]}}</div>
+        </div>
+       
         </div>
     </div>
     <div *ngIf="extra.multiple">

--- a/manager2/src/app/user/user-extra.component.html
+++ b/manager2/src/app/user/user-extra.component.html
@@ -23,7 +23,7 @@
         <label class="form-check-label">
             {{choice[1]}}
         </label>
-        <div *ngIf="extra.responsive">
+        <div *ngIf="extra.feedback">
  <div class="alert {{choice[2]}}" role="alert" *ngIf="extra.value == choice[0]">{{choice[3]}}</div>
         </div>
        

--- a/manager2/src/app/user/user-extra.component.html
+++ b/manager2/src/app/user/user-extra.component.html
@@ -19,7 +19,7 @@
     <div *ngIf="!extra.multiple">
      <div class="form-extra-title">{{extra.description || extra.title}}</div>
         <div *ngFor="let choice of extra.choices">
-        <input type="radio" class="form-check-input" (change)="extraChange(extra.title, $event)" [checked]="extra.value==choice[0]" [value]="choice[0]" [name]="extra.title" data-toggle="alert" data-placement="bottom" title="tooltip on radio!">
+        <input type="radio" class="form-check-input" (change)="extraChange(extra.title, $event)" [checked]="extra.value==choice[0]" [value]="choice[0]" [name]="extra.title">
         <label class="form-check-label">
             {{choice[1]}}
         </label>

--- a/manager2/src/app/user/user-extra.component.html
+++ b/manager2/src/app/user/user-extra.component.html
@@ -20,7 +20,7 @@
      <div class="form-extra-title">{{extra.description || extra.title}}</div>
         <div *ngFor="let choice of extra.choices">
         <input type="radio" class="form-check-input" (change)="extraChange(extra.title, $event)" [checked]="extra.value==choice[0]" [value]="choice[0]" [name]="extra.title">
-        <label class="form-check-label">
+        <label class="form-check-label" data-toggle="tooltip" data-placement="bottom" title="tooltip on radio!">
             {{choice[1]}}
         </label>
         </div>


### PR DESCRIPTION
The goal is to give an immediate feedback to the user based on the type of data he wants to work with using the Genouest services when requesting an account. 
Using the config file, the admin can now give feedback using bootstrap alerts syntax. 