### PR TITLE
Fix issue #446: Add 'duration' selector on project request 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ tests/home_dir
 manager2/node_modules
 manager2/dist
 templates/default/user/*
+dev_quickstart/.env

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ tests/home_dir
 manager2/node_modules
 manager2/dist
 templates/default/user/*
-dev_quickstart/.env
+dev_quickstart/env.sh

--- a/core/project.service.js
+++ b/core/project.service.js
@@ -125,6 +125,7 @@ async function create_project_request(asked_project, user) {
             '#NAME#': asked_project.id,
             '#SIZE#': asked_project.size,
             '#CPU#': asked_project.cpu,
+            '#EXPIRE#': asked_project.expire.toISOString().split('T')[0],
             '#ORGA#': asked_project.orga,
             '#DESC#': asked_project.description
         });

--- a/manager2/src/app/admin/project/project.component.ts
+++ b/manager2/src/app/admin/project/project.component.ts
@@ -162,18 +162,19 @@ export class ProjectComponent implements OnInit {
     }
 
     update_project(project) {
+        const project_to_send = { ...project, expire: new Date(project.expire).getTime()}
         this.projectsService.update(
             project.id,
             {
-                'size': project.size,
-                'cpu': project.cpu,
-                'expire': new Date(project.expire).getTime(),
-                'owner': project.owner,
-                'group': this.config.project.enable_group ? project.group : '',
-                'description' : project.description,
-                'access' : project.access,
-                'path': project.path,
-                'orga':project.orga
+                'size': project_to_send.size,
+                'cpu': project_to_send.cpu,
+                'expire': project_to_send.expire,
+                'owner': project_to_send.owner,
+                'group': this.config.project_to_send.enable_group ? project_to_send.group : '',
+                'description' : project_to_send.description,
+                'access' : project_to_send.access,
+                'path': project_to_send.path,
+                'orga':project_to_send.orga
             }
         ).subscribe(
             resp => {

--- a/manager2/src/app/admin/project/project.component.ts
+++ b/manager2/src/app/admin/project/project.component.ts
@@ -170,7 +170,7 @@ export class ProjectComponent implements OnInit {
                 'cpu': project_to_send.cpu,
                 'expire': project_to_send.expire,
                 'owner': project_to_send.owner,
-                'group': this.config.project_to_send.enable_group ? project_to_send.group : '',
+                'group': this.config.project.enable_group ? project_to_send.group : '',
                 'description' : project_to_send.description,
                 'access' : project_to_send.access,
                 'path': project_to_send.path,

--- a/manager2/src/app/admin/project/project.component.ts
+++ b/manager2/src/app/admin/project/project.component.ts
@@ -151,7 +151,7 @@ export class ProjectComponent implements OnInit {
             this.userService.removeFromProject(userList[i].uid, project.id)
                 .subscribe(
                     resp => {},
-                    err => this.prj_err_msg = err.error.message                                         );
+                    err => this.prj_err_msg = err.error.message);
         }
         this.projectsService.delete(project.id).subscribe(
             resp => {
@@ -162,21 +162,8 @@ export class ProjectComponent implements OnInit {
     }
 
     update_project(project) {
-        const project_to_send = { ...project, expire: new Date(project.expire).getTime()}
-        this.projectsService.update(
-            project.id,
-            {
-                'size': project_to_send.size,
-                'cpu': project_to_send.cpu,
-                'expire': project_to_send.expire,
-                'owner': project_to_send.owner,
-                'group': this.config.project.enable_group ? project_to_send.group : '',
-                'description' : project_to_send.description,
-                'access' : project_to_send.access,
-                'path': project_to_send.path,
-                'orga':project_to_send.orga
-            }
-        ).subscribe(
+        const project_to_send = {...project, expire: new Date(project.expire).getTime(), group: this.config.project.enable_group ? project.group : ''}
+        this.projectsService.update(project.id, project_to_send).subscribe(
             resp => {
                 this.prj_msg = resp['message'];
                 if(this.config.project.enable_group && project.group !== this.oldGroup) {

--- a/manager2/src/app/admin/projects/projects.component.html
+++ b/manager2/src/app/admin/projects/projects.component.html
@@ -120,6 +120,7 @@
                   <th pSortableColumn="created_at">Request <p-sortIcon field="created_at"></p-sortIcon></th>
                   <th pSortableColumn="id">Project <p-sortIcon field="id"></p-sortIcon></th>
                   <th pSortableColumn="owner">User <p-sortIcon field="owner"></p-sortIcon></th>
+                  <th pSortableColumn="expire">Expiration <p-sortIcon field="expire"></p-sortIcon></th>
                   <th pSortableColumn="size">Size (GB) <p-sortIcon field="size"></p-sortIcon></th>
                   <th>Cpu (Hour)</th>
                   <th>Org</th>
@@ -131,6 +132,7 @@
                   <td>{{date_convert(pending.created_at)}}</td>
                   <td>{{pending.id}}</td>
                   <td>{{pending.owner}}</td>
+                  <td>{{date_convert(project.expire)}}</td>
                   <td>{{pending.size}}</td>
                   <td>{{pending.cpu}}</td>
                   <td>{{pending.orga}}</td>

--- a/manager2/src/app/admin/projects/projects.component.html
+++ b/manager2/src/app/admin/projects/projects.component.html
@@ -129,10 +129,10 @@
               </ng-template>
               <ng-template pTemplate="body" let-pending>
                 <tr>
-                  <td>{{date_convert(pending.created_at)}}</td>
+                  <td>{{pending.created_at | date}}</td>
                   <td>{{pending.id}}</td>
                   <td>{{pending.owner}}</td>
-                  <td>{{date_convert(project.expire)}}</td>
+                  <td>{{pending.expire | date}}</td>
                   <td>{{pending.size}}</td>
                   <td>{{pending.cpu}}</td>
                   <td>{{pending.orga}}</td>
@@ -209,8 +209,8 @@
                   value="{{project.current_cpu}}">
               </meter>
           </td>
-          <td>{{date_convert(project.created_at)}}</td>
-          <td>{{date_convert(project.expire)}}</td>
+          <td>{{project.created_at | date}}</td>
+          <td>{{project.expire | date}}</td>
         </tr>
       </ng-template>
     </p-table>
@@ -274,8 +274,8 @@
                     value="{{project.current_cpu}}">
                 </meter>
             </td>
-            <td>{{date_convert(project.created_at)}}</td>
-            <td>{{date_convert(project.expire)}}</td>
+            <td>{{project.created_at | date}}</td>
+            <td>{{project.expire | date}}</td>
             <td>{{project.expiration_notif}}</td>
           </tr>
         </ng-template>

--- a/manager2/src/app/admin/projects/projects.component.html
+++ b/manager2/src/app/admin/projects/projects.component.html
@@ -50,7 +50,7 @@
         </div>
         <div class="col-sm-2">
           <label for="project_expire">Expiration date</label>
-          <input type="date" id="project_expire" [ngModelOptions]="{standalone: true}" [(ngModel)]="new_project.expire" class="form-control"/>
+          <input type="date" id="project_expire" [ngModelOptions]="{standalone: true}" [ngModel]="date_convert(new_project.expire)" (ngModelChange)="date_convert_unix($event)" class="form-control"/>
         </div>
         <div class="col-sm-2">
           <label for="project_org">Financing&nbsp;

--- a/manager2/src/app/admin/projects/projects.component.html
+++ b/manager2/src/app/admin/projects/projects.component.html
@@ -50,7 +50,7 @@
         </div>
         <div class="col-sm-2">
           <label for="project_expire">Expiration date</label>
-          <input type="date" id="project_expire" [ngModelOptions]="{standalone: true}" [ngModel]="date_convert(new_project.expire)" (ngModelChange)="date_convert_unix($event)" class="form-control"/>
+          <input type="date" id="project_expire" [ngModelOptions]="{standalone: true}" [(ngModel)]="new_project.expire" class="form-control"/>
         </div>
         <div class="col-sm-2">
           <label for="project_org">Financing&nbsp;

--- a/manager2/src/app/admin/projects/projects.component.ts
+++ b/manager2/src/app/admin/projects/projects.component.ts
@@ -290,7 +290,7 @@ export class ProjectsComponent implements OnInit {
     }
 
     modify_project(project) {
-        this.new_project = project;
+        this.new_project = {...project, expire: new Date(project.expire)};
         this.update_project_on_event(project.id);
     }
 

--- a/manager2/src/app/admin/projects/projects.component.ts
+++ b/manager2/src/app/admin/projects/projects.component.ts
@@ -168,18 +168,19 @@ export class ProjectsComponent implements OnInit {
             return;
         }
         this.reset_msgs()
+        const project_to_send = { ...this.new_project, expire: new Date(this.new_project.expire).getTime()}
         this.projectService.add({
-            'uuid': this.new_project.uuid,
-            'id': this.new_project.id,
-            'expire': new Date(this.new_project.expire).getTime(),
-            'owner': this.new_project.owner,
-            'group': this.config.project.enable_group ? this.new_project.group : '',
-            'size': this.new_project.size,
-            'cpu': this.new_project.cpu,
-            'description': this.new_project.description,
-            'access': this.new_project.access,
-            'orga': this.new_project.orga,
-            'path': this.new_project.path
+            'uuid': project_to_send.uuid,
+            'id': project_to_send.id,
+            'expire': project_to_send.expire,
+            'owner': project_to_send.owner,
+            'group': this.config.project.enable_group ? project_to_send.group : '',
+            'size': project_to_send.size,
+            'cpu': project_to_send.cpu,
+            'description': project_to_send.description,
+            'access': project_to_send.access,
+            'orga': project_to_send.orga,
+            'path': project_to_send.path
         }).subscribe(
             resp => {
                 this.add_project_msg = resp.message;

--- a/manager2/src/app/admin/projects/projects.component.ts
+++ b/manager2/src/app/admin/projects/projects.component.ts
@@ -318,7 +318,7 @@ export class ProjectsComponent implements OnInit {
     modify_project(project) {
         const project_to_send = { ...project, expire: new Date(project.expire)}
         this.new_project = project_to_send;
-        this.update_project_on_event(project.id);
+        this.update_project_on_event(project_to_send.id);
     }
 
     reject_project(project) {

--- a/manager2/src/app/admin/projects/projects.component.ts
+++ b/manager2/src/app/admin/projects/projects.component.ts
@@ -150,7 +150,7 @@ export class ProjectsComponent implements OnInit {
         if (!this.new_project.expire) {
             this.new_project.expire = this.date_convert(new Date().getTime() + this.config.project.default_expire * this.day_time)
         }
-        
+
         if (!this.new_project.size || this.new_project.size == 0) {
             this.new_project.size = this.default_size;
         }
@@ -195,9 +195,9 @@ export class ProjectsComponent implements OnInit {
             }
         );
     }
-    
+
     edit_project() {
-        
+
         if (!this.new_project.id || (this.config.project.enable_group && !this.new_project.group) || !this.new_project.owner || !this.new_project.expire) {
             this.add_project_error_msg = "Project Id, group, owner and expiration date are required fields " + this.new_project.id + this.new_project.group + this.new_project.owner + this.date_convert(this.new_project.expire);
             return;

--- a/manager2/src/app/admin/projects/projects.component.ts
+++ b/manager2/src/app/admin/projects/projects.component.ts
@@ -147,6 +147,10 @@ export class ProjectsComponent implements OnInit {
         // about order, see: https://medium.com/@lukaonik/how-to-fix-the-previous-ngmodelchange-previous-value-in-angular-6c2838c3407d
         this.new_project.id = tmpprojectid; // todo: maybe add an option to enable or disable this one
 
+        if (!this.new_project.expire) {
+            this.new_project.expire = this.date_convert(new Date().getTime() + this.config.project.default_expire * this.day_time)
+        }
+        
         if (!this.new_project.size || this.new_project.size == 0) {
             this.new_project.size = this.default_size;
         }

--- a/manager2/src/app/admin/projects/projects.component.ts
+++ b/manager2/src/app/admin/projects/projects.component.ts
@@ -147,10 +147,6 @@ export class ProjectsComponent implements OnInit {
         // about order, see: https://medium.com/@lukaonik/how-to-fix-the-previous-ngmodelchange-previous-value-in-angular-6c2838c3407d
         this.new_project.id = tmpprojectid; // todo: maybe add an option to enable or disable this one
 
-        if (!this.new_project.expire) {
-            this.new_project.expire = this.date_convert(new Date().getTime() + this.config.project.default_expire * this.day_time)
-        }
-
         if (!this.new_project.size || this.new_project.size == 0) {
             this.new_project.size = this.default_size;
         }
@@ -168,13 +164,14 @@ export class ProjectsComponent implements OnInit {
         this.notification = "";
 
         if (!this.new_project.id || (this.config.project.enable_group && !this.new_project.group) || !this.new_project.owner) {
-            this.add_project_error_msg = "Project Id, group, and owner are required fields " + this.new_project.id + this.new_project.group + this.new_project.owner;
+            this.add_project_error_msg = "Project Id, group, owner and expiration date are required fields " + this.new_project.id + this.new_project.group + this.new_project.owner + this.date_convert(this.new_project.expire);
             return;
         }
         this.reset_msgs()
         this.projectService.add({
             'uuid': this.new_project.uuid,
             'id': this.new_project.id,
+            'expire': new Date(this.new_project.expire).getTime(),
             'owner': this.new_project.owner,
             'group': this.config.project.enable_group ? this.new_project.group : '',
             'size': this.new_project.size,
@@ -182,8 +179,7 @@ export class ProjectsComponent implements OnInit {
             'description': this.new_project.description,
             'access': this.new_project.access,
             'orga': this.new_project.orga,
-            'path': this.new_project.path,
-            'expire': new Date(this.new_project.expire).getTime()
+            'path': this.new_project.path
         }).subscribe(
             resp => {
                 this.add_project_msg = resp.message;
@@ -206,11 +202,11 @@ export class ProjectsComponent implements OnInit {
             }
         );
     }
-
+    
     edit_project() {
-
-        if (!this.new_project.id || (this.config.project.enable_group && !this.new_project.group) || !this.new_project.owner) {
-            this.add_project_error_msg = "Project Id, group, and owner are required fields " + this.new_project.id + this.new_project.group + this.new_project.owner;
+        
+        if (!this.new_project.id || (this.config.project.enable_group && !this.new_project.group) || !this.new_project.owner || !this.new_project.expire) {
+            this.add_project_error_msg = "Project Id, group, owner and expiration date are required fields " + this.new_project.id + this.new_project.group + this.new_project.owner + this.date_convert(this.new_project.expire);
             return;
         }
 

--- a/manager2/src/app/admin/projects/projects.component.ts
+++ b/manager2/src/app/admin/projects/projects.component.ts
@@ -212,20 +212,20 @@ export class ProjectsComponent implements OnInit {
         }
 
         this.reset_msgs()
-
+        const project_to_send = {...this.new_project, expire: new Date(this.new_project.expire).getTime()}
         this.projectService.edit(
             {
-                'id': this.new_project.id,
-                'uuid': this.new_project.uuid,
-                'size': this.new_project.size,
-                'cpu': this.new_project.cpu,
-                'expire': new Date(this.new_project.expire).getTime(),
-                'owner': this.new_project.owner,
-                'group': this.config.project.enable_group ? this.new_project.group : '',
-                'description': this.new_project.description,
-                'access': this.new_project.access,
-                'path': this.new_project.path,
-                'orga': this.new_project.orga
+                'id': project_to_send.id,
+                'uuid': project_to_send.uuid,
+                'size': project_to_send.size,
+                'cpu': project_to_send.cpu,
+                'expire': project_to_send.expire,
+                'owner': project_to_send.owner,
+                'group': this.config.project.enable_group ? project_to_send.group : '',
+                'description': project_to_send.description,
+                'access': project_to_send.access,
+                'path': project_to_send.path,
+                'orga': project_to_send.orga
             }
         ).subscribe(
             resp => {

--- a/manager2/src/app/admin/projects/projects.component.ts
+++ b/manager2/src/app/admin/projects/projects.component.ts
@@ -290,7 +290,7 @@ export class ProjectsComponent implements OnInit {
     }
 
     modify_project(project) {
-        this.new_project = {...project, expire: new Date(project.expire)};
+        this.new_project = {...project, expire: this.date_convert(project.expire)};
         this.update_project_on_event(project.id);
     }
 

--- a/manager2/src/app/admin/projects/projects.component.ts
+++ b/manager2/src/app/admin/projects/projects.component.ts
@@ -168,20 +168,8 @@ export class ProjectsComponent implements OnInit {
             return;
         }
         this.reset_msgs()
-        const project_to_send = { ...this.new_project, expire: new Date(this.new_project.expire).getTime()}
-        this.projectService.add({
-            'uuid': project_to_send.uuid,
-            'id': project_to_send.id,
-            'expire': project_to_send.expire,
-            'owner': project_to_send.owner,
-            'group': this.config.project.enable_group ? project_to_send.group : '',
-            'size': project_to_send.size,
-            'cpu': project_to_send.cpu,
-            'description': project_to_send.description,
-            'access': project_to_send.access,
-            'orga': project_to_send.orga,
-            'path': project_to_send.path
-        }).subscribe(
+        const project_to_send = {...this.new_project, expire: new Date(this.new_project.expire).getTime(), group: this.config.project.enable_group ? this.new_project.group : ''}
+        this.projectService.add(project_to_send).subscribe(
             resp => {
                 this.add_project_msg = resp.message;
                 this.project_list();
@@ -212,22 +200,8 @@ export class ProjectsComponent implements OnInit {
         }
 
         this.reset_msgs()
-        const project_to_send = {...this.new_project, expire: new Date(this.new_project.expire).getTime()}
-        this.projectService.edit(
-            {
-                'id': project_to_send.id,
-                'uuid': project_to_send.uuid,
-                'size': project_to_send.size,
-                'cpu': project_to_send.cpu,
-                'expire': project_to_send.expire,
-                'owner': project_to_send.owner,
-                'group': this.config.project.enable_group ? project_to_send.group : '',
-                'description': project_to_send.description,
-                'access': project_to_send.access,
-                'path': project_to_send.path,
-                'orga': project_to_send.orga
-            }
-        ).subscribe(
+        const project_to_send = {...this.new_project, expire: new Date(this.new_project.expire).getTime(), group: this.config.project.enable_group ? this.new_project.group : ''}
+        this.projectService.edit(project_to_send).subscribe(
             resp => {
                 this.add_project_msg = resp['message'];
             },

--- a/manager2/src/app/admin/projects/projects.component.ts
+++ b/manager2/src/app/admin/projects/projects.component.ts
@@ -310,11 +310,6 @@ export class ProjectsComponent implements OnInit {
         return res;
     }
 
-    date_convert_unix = function updateUnixTime(dateValue: string) {
-        const tsp = new Date(dateValue);
-        this.new_project.expire = tsp.getTime();
-    }
-
     accept_project(project) {
         this.modify_project(project);
         this.add_project();

--- a/manager2/src/app/admin/projects/projects.component.ts
+++ b/manager2/src/app/admin/projects/projects.component.ts
@@ -309,6 +309,11 @@ export class ProjectsComponent implements OnInit {
         return res;
     }
 
+    date_convert_unix = function updateUnixTime(dateValue: string) {
+        const tsp = new Date(dateValue);
+        this.new_project.expire = tsp.getTime();
+    }
+
     accept_project(project) {
         this.modify_project(project);
         this.add_project();

--- a/manager2/src/app/admin/projects/projects.component.ts
+++ b/manager2/src/app/admin/projects/projects.component.ts
@@ -315,7 +315,8 @@ export class ProjectsComponent implements OnInit {
     }
 
     modify_project(project) {
-        this.new_project = project;
+        const project_to_send = { ...project, expire: new Date(project.expire)}
+        this.new_project = project_to_send;
         this.update_project_on_event(project.id);
     }
 

--- a/manager2/src/app/admin/projects/projects.component.ts
+++ b/manager2/src/app/admin/projects/projects.component.ts
@@ -290,9 +290,8 @@ export class ProjectsComponent implements OnInit {
     }
 
     modify_project(project) {
-        const project_to_send = { ...project, expire: new Date(project.expire)}
-        this.new_project = project_to_send;
-        this.update_project_on_event(project_to_send.id);
+        this.new_project = project;
+        this.update_project_on_event(project.id);
     }
 
     reject_project(project) {

--- a/manager2/src/app/project/project.component.html
+++ b/manager2/src/app/project/project.component.html
@@ -118,8 +118,8 @@
                         value="{{project.current_cpu}}">
                     </meter>
                 </td>
-                <td>{{date_convert(project.created_at)}}</td>
-                <td>{{date_convert(project.expire)}}</td>
+                <td>{{project.created_at | date}}</td>
+                <td>{{project.expire | date}}</td>
                 <td>
                     <button *ngIf="!session_user.is_admin && project.owner != session_user.uid" type="button" class="p-button p-button-sm p-button-warning" (click)="request_user(project, session_user.uid,'remove')">Leave</button>
                     <button *ngIf="session_user.is_admin" type="button" class="p-button p-button-sm p-button-danger" (click)="router.navigate(['/admin/project/' + project.id])">Admin</button>

--- a/manager2/src/app/project/project.component.html
+++ b/manager2/src/app/project/project.component.html
@@ -18,6 +18,14 @@
           </div>
 
           <div class="form-group row col-sm-8">
+            <label for="new_project_expire">Expiration date&nbsp;
+              <span style="color:red">(required)&nbsp;</span>
+              <span class="glyphicon glyphicon-question-sign" title="Project expiration date" tooltip></span>
+            </label>
+            <input required type="date" id="new_project_expire" [ngModelOptions]="{standalone: true}" [(ngModel)]="new_project.expire" class="form-control"/>
+          </div>
+
+          <div class="form-group row col-sm-8">
               <label for="new_project_size">Total expected project size (GB)</label>
               <input placeholder="project size in GB" type="number" id="new_project_size" [value]="default_size" [ngModelOptions]="{standalone: true}" [(ngModel)]="new_project.size" class="form-control"/>
               <small id="nameHelp" class="form-text text-muted"><i>Please include the <b>total</b> expected size for this project.</i></small>

--- a/manager2/src/app/project/project.component.ts
+++ b/manager2/src/app/project/project.component.ts
@@ -223,18 +223,6 @@ export class ProjectComponent implements OnInit {
         );
     }
 
-    date_convert = function timeConverter(tsp) {
-        let res;
-        try {
-            var a = new Date(tsp);
-            res = a.toISOString().substring(0, 10);
-        }
-        catch (e) {
-            res = '';
-        }
-        return res;
-    }
-
     scroll(el: HTMLElement) {
         el.scrollIntoView({behavior: 'smooth'});
     }

--- a/manager2/src/app/project/project.component.ts
+++ b/manager2/src/app/project/project.component.ts
@@ -114,9 +114,14 @@ export class ProjectComponent implements OnInit {
             this.request_err_msg = 'Project name is mandatory';
             return;
         }
-        this.projectsService.askNew(this.new_project).subscribe(
+        if (!this.new_project.expire) {
+            this.request_err_msg = 'Project expiration date is mandatory';
+            return;
+        }
+        const project_to_send = { ...this.new_project, expire: new Date(this.new_project.expire).getTime()}
+        this.projectsService.askNew(project_to_send).subscribe(
             resp => {
-                this.request_msg = 'An email have been sent to admin';
+                this.request_msg = 'An email has been sent to an admin';
                 this.new_project = {};
             },
             err => {

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -1,4 +1,4 @@
-/* TODO : create a core/project.service.js and move all method in it */
+/* TODO : create a core/project.service.js and move all methods into it */
 
 const express = require('express');
 var router = express.Router();
@@ -458,6 +458,7 @@ router.post('/ask/project', async function(req, res){
             'group': user.group,
             'size': req.body.size,
             'cpu': req.body.cpu,
+            'expire': req.body.expire,
             'description': req.body.description,
             'orga': req.body.orga
         }, user);


### PR DESCRIPTION
Is this sufficient for fixing the issue ?
As I understand, an admin is supposed to create each project manually anyway, copying the information off of the email they were sent. This means that now, they'll have to copy the expiration date manually as well. Is there a better way of doing things when add_project (from manager2/src/app/admin/projects.component.ts) is executed ?