### PR TITLE
#132: add a link to the owner profile, in order to get his email easily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added 'End date' to the projet request page
 * Set 'description' as a required field in the projet request page and set a minimal length of 30 char
+* Added a link to user profile on admin panels -> projects pending table
 
 ## 1.4.29
 

--- a/manager2/src/app/admin/projects/projects.component.html
+++ b/manager2/src/app/admin/projects/projects.component.html
@@ -131,7 +131,7 @@
                 <tr>
                   <td>{{pending.created_at | date}}</td>
                   <td>{{pending.id}}</td>
-                  <td>{{pending.owner}}</td>
+                  <td><a routerLink="/user/{{pending.owner}}"><span class="p-button p-button-sm p-button-primary">{{pending.owner}}</span></a></td>
                   <td>{{pending.expire | date}}</td>
                   <td>{{pending.size}}</td>
                   <td>{{pending.cpu}}</td>


### PR DESCRIPTION
Related to this issue : https://gitlab.com/ifb-elixirfr/cluster/dashboard/account-manager/-/issues/132