### PR TITLE
better admin project selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Add back button from single project view
 * Updated TP calendar to increase readability
 * Fix newly created group selection bug
+* Update admin project creation UI: disappearing buttons and add "undo selection" button
 
 ## 1.4.29
 

--- a/manager2/src/app/admin/projects/projects.component.html
+++ b/manager2/src/app/admin/projects/projects.component.html
@@ -84,12 +84,16 @@
       </div>
       <div class="form-group row">
         <div class="col-sm-2">
+          <label style="opacity: 0;">Create</label>
+          <button type="button" class="p-button p-button-success" (click)="add_project()">Create project</button>
+        </div>
+        <div class="col-sm-2" *ngIf="new_project.uuid && new_project.uuid != ''">
           <label style="opacity: 0;">Edit</label>
           <button type="button" class="p-button" (click)="edit_project()">Save changes</button>
         </div>
-        <div class="col-sm-2">
-          <label style="opacity: 0;">Create</label>
-          <button type="button" class="p-button p-button-success" (click)="add_project()">Create project</button>
+        <div class="col-sm-2" *ngIf="new_project.uuid && new_project.uuid != ''">
+          <label style="opacity: 0;">De-select</label>
+          <button type="button" class="p-button p-button-secondary" (click)="new_project = { };">Undo selection</button>
         </div>
       </div>
     </form>


### PR DESCRIPTION
@mboudet 
closes #438 

Most of the issue seems to have already been resolved. The `add_project` method is already used to create new projects even if there they have no uuid and in my test environment, new projects seems to to be created correctly even when none have been selected by the admin.

All I had to add were some esthetic modifications: the "Save changes" button only appears when a pending project has been selected and I added an "Undo selection" to de-select the selected project request if the admin wants to create a new project after having selected a pending project.

Let me know if I missed anything.