### PR TITLE
Change ldapmodify usage since ubuntu22

### DIFF
--- a/templates/abims/user/modify_user.sh
+++ b/templates/abims/user/modify_user.sh
@@ -4,7 +4,7 @@ echo "Start modify_user.sh in $0 ..."
 
 set -e
 
-ldapmodify -h {{ CONFIG.ldap.host }} -cx -w '{{ CONFIG.ldap.admin_password }}' -D {{ CONFIG.ldap.admin_cn }},{{ CONFIG.ldap.admin_dn }} -f "{{ CONFIG.general.script_dir }}/{{ user.uid }}.{{ fid }}.ldif"
+ldapmodify -H ldap://{{ CONFIG.ldap.host }} -cx -w '{{ CONFIG.ldap.admin_password }}' -D {{ CONFIG.ldap.admin_cn }},{{ CONFIG.ldap.admin_dn }} -f "{{ CONFIG.general.script_dir }}/{{ user.uid }}.{{ fid }}.ldif"
 
 {% if user.password %}
 mel add-samba "{{ user.uid }}" --password "{{ user.password }}"

--- a/templates/abims/user/reset_password.sh
+++ b/templates/abims/user/reset_password.sh
@@ -4,7 +4,7 @@ echo "Start reset_password.sh in $0 ..."
 
 set -e
 
-ldapmodify -h {{ CONFIG.ldap.host }} -cx -w '{{ CONFIG.ldap.admin_password }}' -D {{ CONFIG.ldap.admin_cn }},{{ CONFIG.ldap.admin_dn }} -f "{{ CONFIG.general.script_dir }}/{{ user.uid }}.{{ fid }}.ldif"
+ldapmodify -H ldap://{{ CONFIG.ldap.host }} -cx -w '{{ CONFIG.ldap.admin_password }}' -D {{ CONFIG.ldap.admin_cn }},{{ CONFIG.ldap.admin_dn }} -f "{{ CONFIG.general.script_dir }}/{{ user.uid }}.{{ fid }}.ldif"
 
 {% if user.password %}
 mel add-samba "{{ user.uid }}" --password "{{ user.password }}"


### PR DESCRIPTION
ldapmodify doesn't propose `-h` since Ubuntu 22.04