### PR TITLE
Tp expiration

### DIFF
--- a/core/tps.service.js
+++ b/core/tps.service.js
@@ -288,11 +288,16 @@ async function remove_tp_reservation(reservation) {
 
 async function extend_tp_reservation(reservation, extension) {
     logger.debug('Extend reservation', reservation);
-
     try {
-        await dbsrv.mongo_reservations().updateOne({ '_id': reservation._id }, {
-            '$set': { 'to': extension.to }
-        });
+        if (extension.expire) {
+            await dbsrv.mongo_reservations().updateOne({ '_id': reservation._id }, {
+                '$set': { 'to': extension.to, 'expire': extension.expire }
+            });
+        } else {
+            await dbsrv.mongo_reservations().updateOne({ '_id': reservation._id }, {
+                '$set': { 'to': extension.to }
+            });
+        }
         await dbsrv.mongo_events().insertOne( {
             'owner': 'auto',
             'date': new Date().getTime(),

--- a/core/tps.service.js
+++ b/core/tps.service.js
@@ -389,12 +389,13 @@ async function create_tp_reservation(reservation_id) {
     }
 }
 
-async function tp_reservation(userId, from_date, to_date, quantity, about, group_or_project, name) {
+async function tp_reservation(userId, from_date, to_date, expire_date, quantity, about, group_or_project, name) {
     // Create a reservation
     let reservation = {
         'owner': userId,
         'from': from_date,
         'to': to_date,
+        'expire': expire_date,
         'quantity': quantity,
         'accounts': [],
         'about': about,

--- a/manager2/src/app/tps/tps.component.html
+++ b/manager2/src/app/tps/tps.component.html
@@ -140,8 +140,8 @@
                         <span style="color:red">(required)&nbsp;</span>
                         <span class="glyphicon glyphicon-question-sign" title="Project expiration date" tooltip></span>
                     </label>
-                    <input required id="new_expire" [ngModelOptions]="{standalone: true}" [(ngModel)]="new_expire" type="date" class="form-control"/>
-                    </div>
+                    <input required id="new_expire" [ngModelOptions]="{standalone: true}" [(ngModel)]="new_toDate" type="date" class="form-control"/>
+                </div>
                 </div>
                 <div class="modal-footer">
                 <div class="form-group row col-sm-12">

--- a/manager2/src/app/tps/tps.component.html
+++ b/manager2/src/app/tps/tps.component.html
@@ -165,7 +165,7 @@
                 <div class="alert alert-success" *ngIf="resmsg">{{resmsg}}</div>
                 <div class="alert alert-danger" *ngIf="reserrmsg">{{reserrmsg}}</div>
                 <form #tpForm="ngForm" role="form" class="user-form form-horizontal" (ngSubmit)="reserve(tpForm)" novalidate>
-
+                    <div class="form-group row">
                     <div class="col-md-4">
                         <label for="quantity" class="control-label">Number of students</label>
                         <input required type="number" class="form-control" [(ngModel)]="quantity" name="quant" #quant="ngModel" id="tp_quantity"/>
@@ -206,6 +206,14 @@
                         </div>
                     </div>
 
+                    <div class="col-md-8">
+                        <label for="expire_date" class="control-label">
+                            Expire <small id="expirationHelp" class="text-muted"><i>(optional, date beyond which TP accounts are unaccessible, but not deleted)</i></small>
+                        </label>
+                        <input required [(ngModel)]="expireDate" type="date" class="form-control" name="expire" #expire="ngModel" id="tp_expire"/>
+                    </div>
+                    </div>
+
                     <div *ngIf="config && config.reservation && config.reservation.show_choice_in_ui" class="form-group row">
                         <div class="col-4">
                             <p>Associate account to:</p>
@@ -224,7 +232,6 @@
                         <label class="control-label"></label>
                         <button type="submit" class="p-button p-button-sm p-button-secondary">Reserve</button>
                     </div>
-
                 </form>
             </div>
         </div>

--- a/manager2/src/app/tps/tps.component.html
+++ b/manager2/src/app/tps/tps.component.html
@@ -70,6 +70,10 @@
                                 <td>{{selectedEvent.end | date}}</td>
                             </tr>
                             <tr>
+                                <th>Expire</th>
+                                <td>{{selectedEvent.expire | date}}</td>
+                            </tr>
+                            <tr>
                                 <th>Name</th>
                                 <td>{{selectedEvent.meta.name}}</td>
                             </tr>
@@ -136,11 +140,20 @@
             <form aria-label="TP extension request form" role="form" class="user-form form-horizonal">
                 <div class="modal-body">
                 <div class="form-group row col-sm-8">
-                    <label for="new_expire">New Expiration Date&nbsp;
+                    <label for="new_to">New End Date&nbsp;
                         <span style="color:red">(required)&nbsp;</span>
-                        <span class="glyphicon glyphicon-question-sign" title="Project expiration date" tooltip></span>
+                        <span class="glyphicon glyphicon-question-sign" title="Project end date" tooltip></span>
                     </label>
-                    <input required id="new_expire" [ngModelOptions]="{standalone: true}" [(ngModel)]="new_toDate" type="date" class="form-control"/>
+                    <input required id="new_to" [ngModelOptions]="{standalone: true}" [(ngModel)]="new_toDate" type="date" class="form-control"/>
+                </div>
+                <div class="form-group row col-sm-12">
+                    <label for="new_expire">
+                        New Expiration Date <small class="text-muted"><i>
+                            (date beyond which TP accounts are unaccessible, but not deleted)
+                            Optional
+                        </i></small>
+                    </label>
+                    <input id="new_expire" [ngModelOptions]="{standalone: true}" [(ngModel)]="new_expireDate" type="date" class="form-control"/>
                 </div>
                 </div>
                 <div class="modal-footer">
@@ -210,7 +223,7 @@
                         <label for="expire_date" class="control-label">
                             Expire <small id="expirationHelp" class="text-muted"><i>(optional, date beyond which TP accounts are unaccessible, but not deleted)</i></small>
                         </label>
-                        <input required [(ngModel)]="expireDate" type="date" class="form-control" name="expire" #expire="ngModel" id="tp_expire"/>
+                        <input [(ngModel)]="expireDate" type="date" class="form-control" name="expire" #expire="ngModel" id="tp_expire"/>
                     </div>
                     </div>
 

--- a/manager2/src/app/tps/tps.component.ts
+++ b/manager2/src/app/tps/tps.component.ts
@@ -40,6 +40,7 @@ export class TpsComponent implements OnInit {
     quantity: number
     fromDate: Date
     toDate: Date
+    expirationDate: Date
     about: string
     authorized: boolean
 
@@ -48,7 +49,7 @@ export class TpsComponent implements OnInit {
 
     activeDayIsOpen: boolean = true;
 
-    new_expire: Date
+    new_toDate: Date
 
     constructor(
         private authService: AuthService,
@@ -111,6 +112,7 @@ export class TpsComponent implements OnInit {
         );
         this.fromDate = new Date();
         this.toDate = new Date();
+        this.expirationDate = new Date();
         this.viewDate = new Date();
         this.quantity = 1;
         this.events = [];
@@ -149,7 +151,8 @@ export class TpsComponent implements OnInit {
             }
             const fromDate = new Date(this.fromDate).getTime();
             const toDate = new Date(this.toDate).getTime();
-            if(isNaN(fromDate) || isNaN(toDate)) {
+            const expirationDate = new Date(this.expirationDate).getTime();
+            if(isNaN(fromDate) || isNaN(toDate) || isNaN(expirationDate)) {
                 this.reserrmsg = 'Invalid date format';
                 return;
             }
@@ -157,14 +160,15 @@ export class TpsComponent implements OnInit {
                 this.reserrmsg = 'End date must be superior to start date';
                 return;
             }
-            if(toDate < new Date().getTime()) {
-                this.reserrmsg = 'End date can not be in the past';
+            if(toDate < new Date().getTime() || expirationDate < new Date().getTime()) {
+                this.reserrmsg = 'End or expiration date can not be in the past';
                 return;
             }
             let reservation = {
                 quantity: this.quantity,
                 from: fromDate,
                 to: toDate,
+                expiration: expirationDate,
                 about: this.about,
                 group_or_project: this.group_or_project,
                 name: this.name
@@ -225,15 +229,15 @@ export class TpsComponent implements OnInit {
     extend_reservation() {
         this.msg = '';
         this.errmsg = '';
-        if(new Date(this.new_expire).getTime() < this.selectedEvent.meta.end) {
+        if(new Date(this.new_toDate).getTime() < this.selectedEvent.meta.end) {
             this.errmsg = 'Extended end date must be after current end date';
             return;
         }
-        if(new Date(this.new_expire).getTime() < new Date().getTime()) {
+        if(new Date(this.new_toDate).getTime() < new Date().getTime()) {
             this.errmsg = 'Extended end date can not be in the past';
             return;
         }
-        const extension = { 'to': new Date(this.new_expire).getTime() };
+        const extension = { 'to': new Date(this.new_toDate).getTime() };
         this.tpService.extend(this.selectedEvent.meta.id, extension).subscribe(
             resp => {
                 this.msg = resp['message'];

--- a/manager2/src/app/tps/tps.component.ts
+++ b/manager2/src/app/tps/tps.component.ts
@@ -50,6 +50,7 @@ export class TpsComponent implements OnInit {
     activeDayIsOpen: boolean = true;
 
     new_toDate: Date
+    new_expireDate: Date
 
     constructor(
         private authService: AuthService,
@@ -80,6 +81,7 @@ export class TpsComponent implements OnInit {
                         title: `${event.owner}, ${event.quantity} students`,
                         start: new Date(event.from),
                         end: new Date(event.to),
+                        expire: new Date(event.expire),
                         color: this.choseColor(event._id, event.over, event.created),
                         meta: {
                             'id': event._id,
@@ -112,7 +114,7 @@ export class TpsComponent implements OnInit {
         );
         this.fromDate = new Date();
         this.toDate = new Date();
-        this.expirationDate = new Date();
+        this.expirationDate = null;
         this.viewDate = new Date();
         this.quantity = 1;
         this.events = [];
@@ -151,7 +153,7 @@ export class TpsComponent implements OnInit {
             }
             const fromDate = new Date(this.fromDate).getTime();
             const toDate = new Date(this.toDate).getTime();
-            const expirationDate = new Date(this.expirationDate).getTime();
+            const expirationDate = this.expirationDate ? new Date(this.expirationDate).getTime() : toDate;
             if(isNaN(fromDate) || isNaN(toDate) || isNaN(expirationDate)) {
                 this.reserrmsg = 'Invalid date format';
                 return;
@@ -229,15 +231,16 @@ export class TpsComponent implements OnInit {
     extend_reservation() {
         this.msg = '';
         this.errmsg = '';
-        if(new Date(this.new_toDate).getTime() < this.selectedEvent.meta.end) {
+        const new_to_Date = new Date(this.new_toDate).getTime();
+        if(new_to_Date < this.selectedEvent.meta.end) {
             this.errmsg = 'Extended end date must be after current end date';
             return;
         }
-        if(new Date(this.new_toDate).getTime() < new Date().getTime()) {
+        if(new_to_Date < new Date().getTime()) {
             this.errmsg = 'Extended end date can not be in the past';
             return;
         }
-        const extension = { 'to': new Date(this.new_toDate).getTime() };
+        const extension = this.new_expireDate ? { 'to': new_to_Date, 'expire': new Date(this.new_expireDate).getTime() } : { 'to': new_to_Date };
         this.tpService.extend(this.selectedEvent.meta.id, extension).subscribe(
             resp => {
                 this.msg = resp['message'];

--- a/routes/tp.js
+++ b/routes/tp.js
@@ -346,6 +346,17 @@ router.put('/tp/:id/reserve/extend', async function(req, res) {
         return;
     }
 
+    if (req.body.expire) {
+        if (req.body.expire < reservation.expire) {
+            res.status(403).send({message: 'Extended expiration date must be after current end date'});
+            return;
+        }
+        if (req.body.expire < new Date().getTime()) {
+            res.status(403).send({message: 'Extended expiration date can not be in the past'});
+            return;
+        }
+    }
+
     try {
         tpssrv.extend_tp_reservation(reservation, req.body);
     } catch (error) {

--- a/routes/tp.js
+++ b/routes/tp.js
@@ -69,6 +69,7 @@ router.post('/tp', async function(req, res) {
         user.uid,
         req.body.from,
         req.body.to,
+        req.body.expire,
         req.body.quantity,
         req.body.about,
         req.body.group_or_project,


### PR DESCRIPTION
@mboudet 
Will close #499 once finished.

In the [notification email after TP creation](https://github.com/rsiminel/genouestaccountmanager/blob/tp-expiration/core/tps.service.js#L193), how should we differentiate between the "expiration" from `CONFIG.tp.extra_expiration` and the "expiration" field that we are adding in this PR?
How should we handle a TP coming to the end of it's expiration date?
Should we just add a button for a TP owner or an admin to make the TP accounts inaccessible to students, like a "Lock" button that activates a "locked" state?