### PR TITLE
Secure buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Add email sent to a project owner when their project is activated
 * Separate global overview from individual group view in admin group management
 * Allow accents in user's first and last names
+* Secure project deletion (and removing users from project) with a confirmation modal
 
 ## 1.4.31 (2024-09-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 * Secure project deletion (and removing users from project) with a confirmation modal
 * Add checks when removing user from a project's linked group
 * Remove 'Home works' message
-
+* Add rejection message for projects
 
 ## 1.4.31 (2024-09-27)
 

--- a/config/default.json.template
+++ b/config/default.json.template
@@ -292,6 +292,16 @@
     "project_expiration_html": [
         "<p>Project for #NAME# will expire at #DATE#</p>"
     ],
+    "project_rejection": [
+        "Your requested project '#PROJECT#' has been rejected by #USER#.",
+        "Reason:",
+        "#MSG#"
+    ],
+    "project_rejection_html": [
+      "<p>Your requested project '#PROJECT#' has been rejected by #USER#.</p>",
+      "<p>Reason:</p>",
+      "<i>#MSG#</i>"
+    ],
     "user_deletion": [
         "Your account #UID# have been deleted by #USER#",
         "Because:",

--- a/config/test.json
+++ b/config/test.json
@@ -232,6 +232,16 @@
     "project_expiration_html": [
         "<p>Project for #NAME# will expire at #DATE#</p>"
     ],
+    "project_rejection": [
+        "Your requested project '#PROJECT#' has been rejected by #USER#.",
+        "Reason:",
+        "#MSG#"
+    ],
+    "project_rejection_html": [
+      "<p>Your requested project '#PROJECT#' has been rejected by #USER#.</p>",
+      "<p>Reason:</p>",
+      "<i>#MSG#</i>"
+    ],
     "user_deletion": [
         "Your account #UID# have been deleted by #USER#",
         "Because:",

--- a/core/project.service.js
+++ b/core/project.service.js
@@ -154,8 +154,9 @@ async function create_project_request(asked_project, user) {
 }
 
 
-async function remove_project_request(uuid, action_owner = 'auto') {
+async function remove_project_request(uuid, action_owner = 'auto', message = '', sendmail = false) {
     logger.info('Remove Project Request' + uuid);
+    const project = await dbsrv.mongo_pending_projects().findOne({ uuid: uuid });
     const result = await dbsrv.mongo_pending_projects().deleteOne({ uuid: uuid });
     if (result.deletedCount === 1) {
         await dbsrv.mongo_events().insertOne({
@@ -164,6 +165,27 @@ async function remove_project_request(uuid, action_owner = 'auto') {
             action: 'remove Pending project ' + uuid,
             logs: [],
         });
+        if (sendmail) {
+            try {
+                const owner = await dbsrv.mongo_users().findOne({ uid: project.owner });
+                let msg_destinations = [
+                    CONFIG.general.accounts,
+                    owner.email,
+                    ...(owner.send_copy_to_support ? [CONFIG.general.support] : [])
+                ];
+                await maisrv.send_notif_mail({
+                    'name': 'project_rejection',
+                    'destinations': msg_destinations,
+                    'subject': 'Project request rejection: ' + project.id
+                }, {
+                    '#PROJECT#': project.id,
+                    '#USER#': action_owner,
+                    '#MSG#': message || 'No explanation provided.'
+                });
+            } catch(error) {
+                logger.error(error);
+            }
+        }
     }
     else {
         throw {code: 404, message: 'No pending project found'};

--- a/core/project.service.js
+++ b/core/project.service.js
@@ -169,7 +169,6 @@ async function remove_project_request(uuid, action_owner = 'auto', message = '',
             try {
                 const owner = await dbsrv.mongo_users().findOne({ uid: project.owner });
                 let msg_destinations = [
-                    CONFIG.general.accounts,
                     owner.email,
                     ...(owner.send_copy_to_support ? [CONFIG.general.support] : [])
                 ];

--- a/manager2/src/app/admin/project/project.component.html
+++ b/manager2/src/app/admin/project/project.component.html
@@ -109,7 +109,7 @@
             </div>
             <div class="col-sm-3">
               <label style="opacity: 0;">Remove member</label>
-              <button type="button" class="p-button p-button-sm p-button-danger" (click)="remove_user()">Remove member</button>
+              <app-my-delete-confirm [onConfirm]="remove_user" button_disp="Remove member"></app-my-delete-confirm>
             </div>
           </div>
         </form>

--- a/manager2/src/app/admin/project/project.component.html
+++ b/manager2/src/app/admin/project/project.component.html
@@ -7,7 +7,7 @@
 			<h4>Project <strong>{{project.id}}</strong></h4>
 		</div>
 		<div class="col-sm-3" >
-			<button class="p-button p-button-sm p-button-danger" (click)="delete_project()">Delete project</button>
+      <app-my-delete-confirm [onConfirm]="delete_project"></app-my-delete-confirm>
 		</div>
 	</div>
 </div>

--- a/manager2/src/app/admin/project/project.component.ts
+++ b/manager2/src/app/admin/project/project.component.ts
@@ -53,6 +53,7 @@ export class ProjectComponent implements OnInit {
 
     ngOnInit() {
         this.delete_project = this.delete_project.bind(this);
+        this.remove_user = this.remove_user.bind(this);
         this.route.params
             .subscribe(params => {
                 let projectId = params.id;

--- a/manager2/src/app/admin/project/project.component.ts
+++ b/manager2/src/app/admin/project/project.component.ts
@@ -52,6 +52,7 @@ export class ProjectComponent implements OnInit {
     }
 
     ngOnInit() {
+        this.delete_project = this.delete_project.bind(this);
         this.route.params
             .subscribe(params => {
                 let projectId = params.id;

--- a/manager2/src/app/admin/projects/projects.component.html
+++ b/manager2/src/app/admin/projects/projects.component.html
@@ -143,7 +143,7 @@
                   <td>
                     <div class="btn-group">
                       <button type="button" style="margin-right: 0px !important; " class="p-button p-button-sm p-button-info " (click)="modify_project(pending)">View</button>
-                      <app-my-delete-confirm [onConfirm]="reject_project" [data]="pending" button_disp="Reject"></app-my-delete-confirm>
+                      <button type="button" style="margin-right: 0px !important; " class="p-button p-button-sm p-button-danger " (click)="reject_project(pending)">Reject</button>
                     </div>
                   </td>
                 </tr>

--- a/manager2/src/app/admin/projects/projects.component.html
+++ b/manager2/src/app/admin/projects/projects.component.html
@@ -88,6 +88,10 @@
           <button type="button" class="p-button p-button-success" (click)="add_project()">Create project</button>
         </div>
         <div class="col-sm-2" *ngIf="new_project.uuid && new_project.uuid != ''">
+          <label style="opacity: 0;">Reject</label>
+          <app-my-delete-confirm [onConfirm]="reject_project" [data]="" [explainMessage]="true" button_disp="Reject project"></app-my-delete-confirm>
+        </div>
+        <div class="col-sm-2" *ngIf="new_project.uuid && new_project.uuid != ''">
           <label style="opacity: 0;">Edit</label>
           <button type="button" class="p-button" (click)="edit_project()">Save changes</button>
         </div>
@@ -128,7 +132,7 @@
                   <th pSortableColumn="size">Size (GB) <p-sortIcon field="size"></p-sortIcon></th>
                   <th>Cpu (Hour)</th>
                   <th>Org</th>
-                  <th>Action</th>
+                  <th></th>
                 </tr>
               </ng-template>
               <ng-template pTemplate="body" let-pending>
@@ -140,12 +144,7 @@
                   <td>{{pending.size}}</td>
                   <td>{{pending.cpu}}</td>
                   <td>{{pending.orga}}</td>
-                  <td>
-                    <div class="btn-group">
-                      <button type="button" style="margin-right: 0px !important; " class="p-button p-button-sm p-button-info " (click)="modify_project(pending)">View</button>
-                      <app-my-delete-confirm [onConfirm]="reject_project" [data]="pending" [explainMessage]="true" button_disp="Reject"></app-my-delete-confirm>
-                    </div>
-                  </td>
+                  <td><button type="button" style="margin-right: 0px !important; " class="p-button p-button-sm p-button-info " (click)="modify_project(pending)">View</button></td>
                 </tr>
               </ng-template>
             </p-table>

--- a/manager2/src/app/admin/projects/projects.component.html
+++ b/manager2/src/app/admin/projects/projects.component.html
@@ -143,7 +143,7 @@
                   <td>
                     <div class="btn-group">
                       <button type="button" style="margin-right: 0px !important; " class="p-button p-button-sm p-button-info " (click)="modify_project(pending)">View</button>
-                      <button type="button" style="margin-right: 0px !important; " class="p-button p-button-sm p-button-danger " (click)="reject_project(pending)">Reject</button>
+                      <app-my-delete-confirm [onConfirm]="reject_project" [data]="pending" button_disp="Reject"></app-my-delete-confirm>
                     </div>
                   </td>
                 </tr>

--- a/manager2/src/app/admin/projects/projects.component.html
+++ b/manager2/src/app/admin/projects/projects.component.html
@@ -143,7 +143,7 @@
                   <td>
                     <div class="btn-group">
                       <button type="button" style="margin-right: 0px !important; " class="p-button p-button-sm p-button-info " (click)="modify_project(pending)">View</button>
-                      <button type="button" style="margin-right: 0px !important; " class="p-button p-button-sm p-button-danger " (click)="reject_project(pending)">Reject</button>
+                      <app-my-delete-confirm [onConfirm]="reject_project" [data]="pending" [explainMessage]="true" button_disp="Reject"></app-my-delete-confirm>
                     </div>
                   </td>
                 </tr>

--- a/manager2/src/app/admin/projects/projects.component.ts
+++ b/manager2/src/app/admin/projects/projects.component.ts
@@ -187,9 +187,9 @@ export class ProjectsComponent implements OnInit {
         );
     }
 
-    reject_project() {
+    reject_project(message: string, sendmail: boolean) {
         this.reset_msgs()
-        this.projectService.delete_pending(this.new_project.uuid).subscribe(
+        this.projectService.delete_pending(this.new_project.uuid, message, sendmail).subscribe(
             resp => {
                 this.pending_msg = resp.message;
                 this.new_project = new Project();

--- a/manager2/src/app/admin/projects/projects.component.ts
+++ b/manager2/src/app/admin/projects/projects.component.ts
@@ -187,6 +187,19 @@ export class ProjectsComponent implements OnInit {
         );
     }
 
+    reject_project() {
+        this.reset_msgs()
+        this.projectService.delete_pending(this.new_project.uuid).subscribe(
+            resp => {
+                this.pending_msg = resp.message;
+                this.new_project = new Project();
+                this.new_project_expire = '';
+                this.pending_list(true);
+            },
+            err => this.pending_err_msg = err.error
+        );
+    }
+
     edit_project() {
 
         if (!this.new_project.id || (this.config.project.enable_group && !this.new_project.group) || !this.new_project.owner || !this.new_project_expire) {
@@ -285,19 +298,6 @@ export class ProjectsComponent implements OnInit {
         this.new_project = project;
         this.new_project_expire = this.date_convert(project.expire);
         this.update_project_on_event(project.id);
-    }
-
-    reject_project(input_project: any) {
-        const project: Project = this.projectService.mapToProject(input_project);
-        this.reset_msgs()
-        this.projectService.delete_pending(project.uuid).subscribe(
-            resp => {
-                this.pending_msg = resp.message;
-                this.pending_list(true);
-            },
-            err => this.pending_err_msg = err.error
-        );
-
     }
 
     reset_msgs() {

--- a/manager2/src/app/admin/projects/projects.component.ts
+++ b/manager2/src/app/admin/projects/projects.component.ts
@@ -64,7 +64,6 @@ export class ProjectsComponent implements OnInit {
     // TODO sort groups by name
 
     ngOnInit() {
-        this.reject_project = this.reject_project.bind(this);
         this.route.queryParams
             .subscribe(params => {
                 if (params.deleted == "ok") {

--- a/manager2/src/app/admin/projects/projects.component.ts
+++ b/manager2/src/app/admin/projects/projects.component.ts
@@ -64,6 +64,7 @@ export class ProjectsComponent implements OnInit {
     // TODO sort groups by name
 
     ngOnInit() {
+        this.reject_project = this.reject_project.bind(this);
         this.route.queryParams
             .subscribe(params => {
                 if (params.deleted == "ok") {

--- a/manager2/src/app/admin/projects/projects.service.ts
+++ b/manager2/src/app/admin/projects/projects.service.ts
@@ -323,7 +323,7 @@ export class ProjectsService {
         }));
     }
 
-    delete_pending(projectUuid: string): Observable<any> {
+    delete_pending(projectUuid: string, message: string, sendmail: boolean): Observable<any> {
         //let user = this.authService.profile;
         let params = new HttpParams();
 
@@ -331,7 +331,11 @@ export class ProjectsService {
             //headers: new HttpHeaders({
             //  'x-api-key': user.apikey
             //}),
-            params: params
+            params: params,
+            body: {
+                message: message,
+                sendmail: sendmail
+            }
         };
         return this.http.delete(
             environment.apiUrl + '/pending/project/' + projectUuid,

--- a/manager2/src/app/my-delete-confirm/my-delete-confirm.component.html
+++ b/manager2/src/app/my-delete-confirm/my-delete-confirm.component.html
@@ -1,6 +1,6 @@
 <div class="deleteConfirmation">
   <div *ngIf="!isDeleting" >
-    <button type="button" class="p-button p-button-sm p-button-danger btn-xs" (click)="startDelete()"><i class="fa fa-trash-o"></i> Delete</button>
+    <button type="button" class="p-button p-button-sm p-button-danger btn-xs" (click)="startDelete()"><i class="fa fa-trash-o"></i>{{button_disp}}</button>
   </div>
   <div *ngIf="isDeleting">
     <div *ngIf="explainMessage">

--- a/manager2/src/app/my-delete-confirm/my-delete-confirm.component.ts
+++ b/manager2/src/app/my-delete-confirm/my-delete-confirm.component.ts
@@ -9,7 +9,7 @@ export class MyDeleteConfirmComponent implements OnInit {
 
     isDeleting: boolean
     message: string
-    sendmail: boolean
+    sendmail: boolean = true
 
     @Input()
     onConfirm: any

--- a/manager2/src/app/my-delete-confirm/my-delete-confirm.component.ts
+++ b/manager2/src/app/my-delete-confirm/my-delete-confirm.component.ts
@@ -20,6 +20,9 @@ export class MyDeleteConfirmComponent implements OnInit {
     @Input()
     explainMessage: boolean
 
+    @Input()
+    button_disp: string = "Delete"
+
     constructor() { }
 
     ngOnInit() {

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -671,8 +671,17 @@ router.delete('/pending/project/:uuid', async function (req, res) {
         return;
     }
 
+    let mail_message = '';
+    let mail_send = false;
+    if (req.body.message) {
+        mail_message = req.body.message;
+    }
+    if (req.body.sendmail) {
+        mail_send = req.body.sendmail;
+    }
+
     try {
-        await prjsrv.remove_project_request(req.params.uuid, user.uid);
+        await prjsrv.remove_project_request(req.params.uuid, user.uid, mail_message, mail_send);
     } catch(e) {
         logger.error(e);
         if (e.code && e.message) {


### PR DESCRIPTION
Closes #561 

Using my-delete-confirm for deleting projects and for removing users form projects.

I thought of using this same method to address issues 507 (Confirmation on project reject) and 554 (Enable email when rejecting project) but that seems to be covered in the open PR #574. Are there any other big red buttons we should shield from miss-clicks, @mboudet ?