### PR TITLE
Add checks when removing user from a project's linked group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Add email sent to a project owner when their project is activated
 * Separate global overview from individual group view in admin group management
 * Allow accents in user's first and last names
+* Add checks when removing user from a project's linked group
 
 ## 1.4.31 (2024-09-27)
 

--- a/core/tps.service.js
+++ b/core/tps.service.js
@@ -76,7 +76,7 @@ async function deleteExtraProject(project) {
         return false;
     }
     try {
-        await usrsrv.remove_user_from_project(project_to_remove.id, project_to_remove.owner, 'auto', true);
+        await usrsrv.remove_user_from_project(project_to_remove.id, project_to_remove.owner, 'auto', false, true);
         let res = await prjsrv.remove_project(project_to_remove.id);
         return res;
     } catch(error) {

--- a/core/user.service.js
+++ b/core/user.service.js
@@ -387,7 +387,7 @@ async function add_user_to_group(uid, secgroup, action_owner = 'auto') {
 
 }
 
-async function remove_user_from_project(oldproject, uid, action_owner = {uid: 'auto', is_admin: false}, force = false) {
+async function remove_user_from_project(oldproject, uid, action_owner = 'auto', action_owner_is_admin = false, force = false) {
     logger.info('Remove user ' + uid + ' from project ' + oldproject);
 
     let fid = new Date().getTime();
@@ -422,12 +422,12 @@ async function remove_user_from_project(oldproject, uid, action_owner = {uid: 'a
         throw {code: 500, message: 'Remove from Project Failed'};
 
     }
-    await dbsrv.mongo_events().insertOne({'owner': action_owner.uid, 'date': new Date().getTime(), 'action': 'remove user ' + uid + ' from project ' + oldproject , 'logs': []});
+    await dbsrv.mongo_events().insertOne({'owner': action_owner, 'date': new Date().getTime(), 'action': 'remove user ' + uid + ' from project ' + oldproject , 'logs': []});
 
     if (project.group && (CONFIG.project === undefined || CONFIG.project.enable_group)) {
         try {
             if (user.group === project.group) {
-                if (action_owner.is_admin) {
+                if (action_owner_is_admin) {
                     throw {code: 403, message: `Cannot remove primary group ${project.group}. Please adjust the group settings first.`};
                 } else {
                     throw {code: 403, message: `Cannot change the primary group of ${user.uid}. Please contact an admin at ${CONFIG.general.support}.`};
@@ -439,7 +439,6 @@ async function remove_user_from_project(oldproject, uid, action_owner = {uid: 'a
         } catch(error) {
             logger.error(`Removal of user from project ${oldproject} group ${project.group} failed`, error);
             throw {code: 500, message: 'Remove from Project Failed'};
-
         }
     }
 }

--- a/core/user.service.js
+++ b/core/user.service.js
@@ -387,7 +387,7 @@ async function add_user_to_group(uid, secgroup, action_owner = 'auto') {
 
 }
 
-async function remove_user_from_project(oldproject, uid, action_owner = 'auto', force = false) {
+async function remove_user_from_project(oldproject, uid, action_owner = {uid: 'auto', is_admin: false}, force = false) {
     logger.info('Remove user ' + uid + ' from project ' + oldproject);
 
     let fid = new Date().getTime();
@@ -422,12 +422,12 @@ async function remove_user_from_project(oldproject, uid, action_owner = 'auto', 
         throw {code: 500, message: 'Remove from Project Failed'};
 
     }
-    await dbsrv.mongo_events().insertOne({'owner': action_owner, 'date': new Date().getTime(), 'action': 'remove user ' + uid + ' from project ' + oldproject , 'logs': []});
+    await dbsrv.mongo_events().insertOne({'owner': action_owner.uid, 'date': new Date().getTime(), 'action': 'remove user ' + uid + ' from project ' + oldproject , 'logs': []});
 
     if (project.group && (CONFIG.project === undefined || CONFIG.project.enable_group)) {
         try {
             if (user.group === project.group) {
-                if (user.is_admin) {
+                if (action_owner.is_admin) {
                     throw {code: 403, message: `Cannot remove primary group ${project.group}. Please adjust the group settings first.`};
                 } else {
                     throw {code: 403, message: `Cannot change the primary group of ${user.uid}. Please contact an admin at ${CONFIG.general.support}.`};

--- a/core/user.service.js
+++ b/core/user.service.js
@@ -426,7 +426,16 @@ async function remove_user_from_project(oldproject, uid, action_owner = 'auto', 
 
     if (project.group && (CONFIG.project === undefined || CONFIG.project.enable_group)) {
         try {
-            await grpsrv.remove_from_group(user.uid, project.group);
+            if (user.group === project.group) {
+                if (user.is_admin) {
+                    throw {code: 403, message: `Cannot remove primary group ${project.group}. Please adjust the group settings first.`};
+                } else {
+                    throw {code: 403, message: `Cannot change the primary group of ${user.uid}. Please contact an admin at ${CONFIG.general.support}.`};
+                }
+            }
+            else if (user.secondarygroups.includes(project.group)) {
+                await grpsrv.remove_from_group(user.uid, project.group);
+            }
         } catch(error) {
             logger.error(`Removal of user from project ${oldproject} group ${project.group} failed`, error);
             throw {code: 500, message: 'Remove from Project Failed'};

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -410,7 +410,7 @@ router.post('/project/:id/request/user', async function(req, res) {
         if (req.body.request === 'add'){
             await usrsrv.add_user_to_project(project.id, req.body.user, user.uid);
         } else if (req.body.request === 'remove') {
-            await usrsrv.remove_user_from_project(project.id, req.body.user, user.uid, false);
+            await usrsrv.remove_user_from_project(project.id, req.body.user, user.uid, user.is_admin, false);
         }
     } catch (e) {
         logger.error(e);

--- a/routes/users.js
+++ b/routes/users.js
@@ -1817,7 +1817,7 @@ router.delete('/user/:id/project/:project', async function(req, res) {
     }
 
     try {
-        await usrsrv.remove_user_from_project(oldproject, uid, session_user, force);
+        await usrsrv.remove_user_from_project(oldproject, uid, session_user.uid, session_user.is_admin, force);
     } catch (e) {
         logger.error(e);
         if (e.code && e.message) {

--- a/routes/users.js
+++ b/routes/users.js
@@ -1817,7 +1817,7 @@ router.delete('/user/:id/project/:project', async function(req, res) {
     }
 
     try {
-        await usrsrv.remove_user_from_project(oldproject, uid, session_user.uid, force);
+        await usrsrv.remove_user_from_project(oldproject, uid, session_user, force);
     } catch (e) {
         logger.error(e);
         if (e.code && e.message) {


### PR DESCRIPTION
We do not remove the user from the group linked to the project if the user in not in the group anymore.
We do not remove the user from the group linked to the project if it is the user's main group.
- If the user is an admin, we send "Cannot remove primary group xxx. Please adjust the group settings first."
- If the user is not an admin, we send "Cannot change the primary group of xxx. Please contact an admin at xxx@xxx."

closes #504 