### PR TITLE
fix database creation validation email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Ensure emails have name, destination and subject
 * Fix bug in TP account deletion
+* Fix database creation validation confirmation email
 
 ## 1.4.32 (2025-04-22)
 

--- a/core/user_db.service.js
+++ b/core/user_db.service.js
@@ -124,10 +124,11 @@ async function create_db(new_db, user, id) {
     }
 
     try {
+        let owner = await dbsrv.mongo_users().findOne({ uid: new_db.owner });
         await maisrv.send_notif_mail(
             {
                 name: 'database_creation',
-                destinations: [user.email, CONFIG.general.accounts],
+                destinations: [owner.email, CONFIG.general.accounts],
                 subject: 'Database creation'
             },
             {


### PR DESCRIPTION
When an admin validates the requested creation of a database, the confirmation email is sent to the new database's owner (aka the person who requested the database's creation), not the admin validating the database creation.

closes #606 