### PR TITLE
Better looking dates in emails (e.g. "2026-06-12")

### DIFF
--- a/cron/test_expiration.js
+++ b/cron/test_expiration.js
@@ -88,7 +88,7 @@ dbsrv.init_db().then(async ()=>{
                 'subject': 'account expiration ' + user.uid
             }, {
                 '#LINK#': link,
-                '#EXPIRE#': timeConverter(user.expiration)
+                '#EXPIRE#': new Date(user.expiration).toISOString().split('T')[0]
             });
 
             if (CONFIG.general.limit_expire_mail) {

--- a/cron/test_projects.js
+++ b/cron/test_projects.js
@@ -85,7 +85,7 @@ dbsrv.init_db().then(async ()=>{
                     'subject': 'Project expiration ' + project.id
                 }, {
                     '#NAME#': project.id,
-                    '#DATE#': timeConverter(project.expire)
+                    '#DATE#': new Date(project.expire).toISOString().split('T')[0]
                 });
 
                 if (CONFIG.general.limit_expire_mail) {


### PR DESCRIPTION
This PR to make the emails less degueulasse:

`Project for foobar will expire at 18,Oct 2025 0:0:0`

will become:

`Project for foobar will expire at 2025-10-18`